### PR TITLE
Fix async_timeout

### DIFF
--- a/bsblan/bsblan.py
+++ b/bsblan/bsblan.py
@@ -69,7 +69,7 @@ class BSBLan:
             self._close_session = True
 
         try:
-            with async_timeout.timeout(self.request_timeout):
+            async with async_timeout.timeout(self.request_timeout):
                 response = await self._session.request(
                     method,
                     url,


### PR DESCRIPTION
The use of with is deprecated, see here:
https://github.com/aio-libs/async-timeout/blob/6e9f8f6aa450f91f42282c83038aed6543c425c6/async_timeout/__init__.py#L73-L85
The following warning is logged during `pytest`:
```
  /usr/local/lib/python3.9/site-packages/bsblan/bsblan.py:72: DeprecationWarning: with timeout() is deprecated, use async with timeout() instead
    with async_timeout.timeout(self.request_timeout):
```
