### PR TITLE
fix max temperature parameter

### DIFF
--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -37,7 +37,7 @@ STATIC_VALUES_API_V1 = {
 
 STATIC_VALUES_API_V3 = {
     "714.0": "min_temp",
-    "730.0": "max_temp",
+    "716.0": "max_temp",
 }
 
 SENSORS_API_V1 = {


### PR DESCRIPTION
The max temperature was still read from (bsblan v1) 730  parameter needs to be 716.0. #89710