### PR TITLE
⬆️ Update package rules to match 'uv' manager for Python dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,16 +11,16 @@
   "commitMessagePrefix": "⬆️",
   "packageRules": [
     {
-      "matchManagers": ["poetry"],
+      "matchManagers": ["uv"],
       "addLabels": ["python"]
     },
     {
-      "matchManagers": ["poetry"],
+      "matchManagers": ["uv"],
       "matchDepTypes": ["dev"],
       "rangeStrategy": "pin"
     },
     {
-      "matchManagers": ["poetry"],
+      "matchManagers": ["uv"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },


### PR DESCRIPTION
This pull request updates the Renovate configuration to use the `uv` dependency manager instead of `poetry` for Python projects. The main effect is that all automated dependency updates and related rules now target `uv`.

Dependency management configuration:

* Updated all `packageRules` in `.github/renovate.json` to match on the `uv` manager instead of `poetry`, affecting labeling, version pinning, and automerge behavior for Python dependencies.