### PR TITLE
Add support for pre-release options in release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -7,6 +7,21 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Create a pre-release (beta)"
+        required: false
+        type: boolean
+        default: false
+      prerelease_identifier:
+        description: "Pre-release identifier"
+        required: false
+        type: choice
+        default: "beta"
+        options:
+          - beta
+          - alpha
+          - rc
 
 jobs:
   update_release_draft:
@@ -15,5 +30,8 @@ jobs:
     steps:
       - name: 🚀 Run Release Drafter
         uses: release-drafter/release-drafter@v6.1.0
+        with:
+          prerelease: ${{ github.event.inputs.prerelease == 'true' }}
+          prerelease-identifier: ${{ github.event.inputs.prerelease_identifier }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request enhances the release workflow configuration by adding support for creating pre-releases (such as beta, alpha, or release candidate versions) directly from the workflow dispatch menu. This makes it easier to manage and automate pre-release versions.

**Release workflow improvements:**

* Added `prerelease` and `prerelease_identifier` input options to the workflow dispatch trigger, allowing users to specify whether to create a pre-release and select its type (`beta`, `alpha`, or `rc`).
* Updated the Release Drafter job to use the new inputs, passing them as parameters to control pre-release creation and labeling.