### PR TITLE
refactor: simplify device attribute assignment in print_device_info

### DIFF
--- a/examples/control.py
+++ b/examples/control.py
@@ -177,8 +177,8 @@ async def print_device_info(device: Device, info: Info) -> None:
     )
 
     attributes = {
-        "Device Name": device.name if device.name else "N/A",
-        "Version": device.version if device.version else "N/A",
+        "Device Name": device.name or "N/A",
+        "Version": device.version or "N/A",
         "Device Identification": device_identification,
     }
     print_attributes("Device Information", attributes)


### PR DESCRIPTION
This pull request makes a small code simplification in the `print_device_info` function. The change replaces the verbose conditional assignment with the more concise `or` operator for defaulting to "N/A" when `device.name` or `device.version` are not set.