### PR TITLE
Consolidate error message constants into ErrorMsg class

### DIFF
--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -18,9 +18,6 @@ from packaging import version as pkg_version
 from yarl import URL
 
 from .constants import (
-    API_DATA_NOT_INITIALIZED_ERROR_MSG,
-    API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG,
-    API_VERSION_ERROR_MSG,
     API_VERSIONS,
     CIRCUIT_HEATING_SECTIONS,
     CIRCUIT_PROBE_PARAMS,
@@ -28,32 +25,17 @@ from .constants import (
     CIRCUIT_STATUS_PARAMS,
     CIRCUIT_THERMOSTAT_PARAMS,
     DHW_TIME_PROGRAM_PARAMS,
-    EMPTY_INCLUDE_LIST_ERROR_MSG,
-    EMPTY_SECTION_PARAMS_ERROR_MSG,
-    FIRMWARE_VERSION_ERROR_MSG,
     HOT_WATER_CONFIG_PARAMS,
     HOT_WATER_ESSENTIAL_PARAMS,
     HOT_WATER_SCHEDULE_PARAMS,
     INACTIVE_CIRCUIT_MARKER,
-    INVALID_CIRCUIT_ERROR_MSG,
-    INVALID_INCLUDE_PARAMS_ERROR_MSG,
-    INVALID_RESPONSE_ERROR_MSG,
     MAX_VALID_YEAR,
     MIN_VALID_YEAR,
-    MULTI_PARAMETER_ERROR_MSG,
-    NO_PARAMETER_IDS_ERROR_MSG,
-    NO_PARAMETER_NAMES_ERROR_MSG,
-    NO_SCHEDULE_ERROR_MSG,
-    NO_STATE_ERROR_MSG,
-    PARAMETER_NAMES_NOT_RESOLVED_ERROR_MSG,
-    SECTION_NOT_FOUND_ERROR_MSG,
-    SESSION_NOT_INITIALIZED_ERROR_MSG,
     SETTABLE_HOT_WATER_PARAMS,
-    TEMPERATURE_RANGE_ERROR_MSG,
     VALID_CIRCUITS,
     VALID_HVAC_MODES,
-    VERSION_ERROR_MSG,
     APIConfig,
+    ErrorMsg,
 )
 from .exceptions import (
     BSBLANAuthError,
@@ -258,7 +240,7 @@ class BSBLAN:
         section validation until the data is needed (lazy loading).
         """
         if self._api_version is None:
-            raise BSBLANError(API_VERSION_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_VERSION)
 
         # Initialize API data if not already done
         if self._api_data is None:
@@ -285,7 +267,7 @@ class BSBLAN:
 
         """
         if not self._api_validator:
-            raise BSBLANError(API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
 
         # Fast path: skip if already validated (no lock needed)
         if self._api_validator.is_section_validated(section):
@@ -335,10 +317,10 @@ class BSBLAN:
             return
 
         if not self._api_validator:
-            raise BSBLANError(API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
 
         if not self._api_data:
-            raise BSBLANError(API_DATA_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
 
         # Get or create lock for this group
         if group_name not in self._hot_water_group_locks:
@@ -424,7 +406,7 @@ class BSBLAN:
         This method is kept for backwards compatibility.
         """
         if self._api_version is None:
-            raise BSBLANError(API_VERSION_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_VERSION)
 
         # Initialize API data if not already done
         if self._api_data is None:
@@ -468,10 +450,10 @@ class BSBLAN:
 
         """
         if not self._api_validator:
-            raise BSBLANError(API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
 
         if not self._api_data:
-            raise BSBLANError(API_DATA_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
 
         # Assign to local variable after asserting it's not None
         api_validator = self._api_validator
@@ -483,7 +465,7 @@ class BSBLAN:
         try:
             section_data = self._api_data[section]
         except KeyError as err:
-            msg = SECTION_NOT_FOUND_ERROR_MSG.format(section)
+            msg = ErrorMsg.SECTION_NOT_FOUND.format(section)
             raise BSBLANError(msg) from err
 
         # Filter to only included params if specified
@@ -592,7 +574,7 @@ class BSBLAN:
 
         """
         if not self._firmware_version:
-            raise BSBLANError(FIRMWARE_VERSION_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.FIRMWARE_VERSION)
 
         version = pkg_version.parse(self._firmware_version)
         if version < pkg_version.parse("1.2.0"):
@@ -603,7 +585,7 @@ class BSBLAN:
         elif version >= pkg_version.parse("3.0.0"):
             self._api_version = "v3"
         else:
-            raise BSBLANVersionError(VERSION_ERROR_MSG)
+            raise BSBLANVersionError(ErrorMsg.VERSION)
 
     async def _fetch_temperature_range(
         self,
@@ -693,7 +675,7 @@ class BSBLAN:
 
         """
         if circuit not in VALID_CIRCUITS:
-            msg = INVALID_CIRCUIT_ERROR_MSG.format(circuit)
+            msg = ErrorMsg.INVALID_CIRCUIT.format(circuit)
             raise BSBLANInvalidParameterError(msg)
 
     @property
@@ -724,7 +706,7 @@ class BSBLAN:
             self._api_data = self._copy_api_config()
             logger.debug("API data initialized for version: %s", self._api_version)
         if self._api_data is None:
-            raise BSBLANError(API_DATA_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
         return self._api_data
 
     def _copy_api_config(self) -> APIConfig:
@@ -738,7 +720,7 @@ class BSBLAN:
 
         """
         if self._api_version is None:
-            raise BSBLANError(API_VERSION_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_VERSION)
         source_config: APIConfig = API_VERSIONS[self._api_version]
         return cast(
             "APIConfig",
@@ -814,7 +796,7 @@ class BSBLAN:
 
         """
         if self.session is None:
-            raise BSBLANError(SESSION_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.SESSION_NOT_INITIALIZED)
         url = self._build_url(base_path)
         auth = self._get_auth()
         headers = self._get_headers()
@@ -838,7 +820,7 @@ class BSBLAN:
             raise
         except (ValueError, UnicodeDecodeError) as e:
             # Handle JSON decode errors and other parsing issues
-            msg = INVALID_RESPONSE_ERROR_MSG.format(e)
+            msg = ErrorMsg.INVALID_RESPONSE.format(e)
             raise BSBLANError(msg) from e
 
     def _process_response(
@@ -976,20 +958,20 @@ class BSBLAN:
 
         # Guard: if validation removed all params, the section is not available
         if not section_params:
-            msg = EMPTY_SECTION_PARAMS_ERROR_MSG.format(section)
+            msg = ErrorMsg.EMPTY_SECTION_PARAMS.format(section)
             raise BSBLANError(msg)
 
         # Filter parameters if include list is specified
         if include is not None:
             if not include:
-                raise BSBLANError(EMPTY_INCLUDE_LIST_ERROR_MSG)
+                raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
             section_params = {
                 param_id: name
                 for param_id, name in section_params.items()
                 if name in include
             }
             if not section_params:
-                raise BSBLANError(INVALID_INCLUDE_PARAMS_ERROR_MSG)
+                raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)
 
         params = await self._extract_params_summary(section_params)
         data = await self._request(params={"Parameter": params["string_par"]})
@@ -1171,7 +1153,7 @@ class BSBLAN:
         self._validate_single_parameter(
             target_temperature,
             hvac_mode,
-            error_msg=MULTI_PARAMETER_ERROR_MSG,
+            error_msg=ErrorMsg.MULTI_PARAMETER,
         )
 
         state = await self._prepare_thermostat_state(
@@ -1247,7 +1229,7 @@ class BSBLAN:
                 await self._initialize_temperature_range(circuit)
 
             if self._min_temp is None or self._max_temp is None:
-                raise BSBLANError(TEMPERATURE_RANGE_ERROR_MSG)
+                raise BSBLANError(ErrorMsg.TEMPERATURE_RANGE)
 
             min_temp = self._min_temp
             max_temp = self._max_temp
@@ -1261,7 +1243,7 @@ class BSBLAN:
             max_temp = temp_range.get("max")
 
             if min_temp is None or max_temp is None:
-                raise BSBLANError(TEMPERATURE_RANGE_ERROR_MSG)
+                raise BSBLANError(ErrorMsg.TEMPERATURE_RANGE)
 
         try:
             temp = float(target_temperature)
@@ -1353,14 +1335,14 @@ class BSBLAN:
         # Apply include filter if specified
         if include is not None:
             if not include:
-                raise BSBLANError(EMPTY_INCLUDE_LIST_ERROR_MSG)
+                raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
             filtered_params = {
                 param_id: name
                 for param_id, name in filtered_params.items()
                 if name in include
             }
             if not filtered_params:
-                raise BSBLANError(INVALID_INCLUDE_PARAMS_ERROR_MSG)
+                raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)
 
         if not filtered_params:
             raise BSBLANError(error_msg)
@@ -1529,7 +1511,7 @@ class BSBLAN:
             params.legionella_function_dwelling_time,
             params.operating_mode_changeover,
             *time_program_params,
-            error_msg=MULTI_PARAMETER_ERROR_MSG,
+            error_msg=ErrorMsg.MULTI_PARAMETER,
         )
 
         state = self._prepare_hot_water_state(params)
@@ -1561,7 +1543,7 @@ class BSBLAN:
 
         """
         if not schedule.has_any_schedule():
-            raise BSBLANError(NO_SCHEDULE_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.NO_SCHEDULE)
 
         # Invert DHW_TIME_PROGRAM_PARAMS to get day_name -> param_id mapping
         # Exclude standard_values as it's not a day of the week
@@ -1611,7 +1593,7 @@ class BSBLAN:
                     state.update({"Parameter": param_id, "Value": value, "Type": "1"})
 
         if not state:
-            raise BSBLANError(NO_STATE_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.NO_STATE)
         return state
 
     # -------------------------------------------------------------------------
@@ -1646,7 +1628,7 @@ class BSBLAN:
 
         """
         if not parameter_ids:
-            raise BSBLANError(NO_PARAMETER_IDS_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.NO_PARAMETER_IDS)
 
         # Request the parameters from the device
         params_string = ",".join(parameter_ids)
@@ -1744,17 +1726,17 @@ class BSBLAN:
 
         """
         if not parameter_names:
-            raise BSBLANError(NO_PARAMETER_NAMES_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.NO_PARAMETER_NAMES)
 
         if not self._api_data:
-            raise BSBLANError(API_DATA_NOT_INITIALIZED_ERROR_MSG)
+            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
 
         # Resolve names to IDs
         name_to_id = self.get_parameter_ids(parameter_names)
 
         if not name_to_id:
             unknown_params = ", ".join(parameter_names)
-            msg = f"{PARAMETER_NAMES_NOT_RESOLVED_ERROR_MSG}: {unknown_params}"
+            msg = f"{ErrorMsg.PARAMETER_NAMES_NOT_RESOLVED}: {unknown_params}"
             raise BSBLANError(msg)
 
         # Fetch parameters by ID

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -463,42 +463,40 @@ def get_hvac_action_category(status_code: int) -> HVACActionCategory:
 
 
 # Error Messages
-NO_STATE_ERROR_MSG: Final[str] = "No state provided."
-NO_SCHEDULE_ERROR_MSG: Final[str] = "No schedule provided."
-VERSION_ERROR_MSG: Final[str] = "Version not supported"
-FIRMWARE_VERSION_ERROR_MSG: Final[str] = "Firmware version not available"
-TEMPERATURE_RANGE_ERROR_MSG: Final[str] = "Temperature range not initialized"
-API_VERSION_ERROR_MSG: Final[str] = "API version not set"
-MULTI_PARAMETER_ERROR_MSG: Final[str] = "Only one parameter can be set at a time"
-SESSION_NOT_INITIALIZED_ERROR_MSG: Final[str] = "Session not initialized"
-API_DATA_NOT_INITIALIZED_ERROR_MSG: Final[str] = "API data not initialized"
-API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG: Final[str] = "API validator not initialized"
-SECTION_NOT_FOUND_ERROR_MSG: Final[str] = "Section '{}' not found in API data"
-INVALID_CIRCUIT_ERROR_MSG: Final[str] = "Invalid circuit number: {}. Must be 1 or 2."
-INVALID_RESPONSE_ERROR_MSG: Final[str] = (
-    "Invalid response format from BSB-LAN device: {}"
-)
-EMPTY_SECTION_PARAMS_ERROR_MSG: Final[str] = (
-    "No valid parameters found for section '{}'. "
-    "The device may not support this circuit or section."
-)
+class ErrorMsg:
+    """Error message constants for BSBLAN."""
+
+    NO_STATE = "No state provided."
+    NO_SCHEDULE = "No schedule provided."
+    VERSION = "Version not supported"
+    FIRMWARE_VERSION = "Firmware version not available"
+    TEMPERATURE_RANGE = "Temperature range not initialized"
+    API_VERSION = "API version not set"
+    MULTI_PARAMETER = "Only one parameter can be set at a time"
+    SESSION_NOT_INITIALIZED = "Session not initialized"
+    API_DATA_NOT_INITIALIZED = "API data not initialized"
+    API_VALIDATOR_NOT_INITIALIZED = "API validator not initialized"
+    SECTION_NOT_FOUND = "Section '{}' not found in API data"
+    INVALID_CIRCUIT = "Invalid circuit number: {}. Must be 1 or 2."
+    INVALID_RESPONSE = "Invalid response format from BSB-LAN device: {}"
+    EMPTY_SECTION_PARAMS = (
+        "No valid parameters found for section '{}'. "
+        "The device may not support this circuit or section."
+    )
+    NO_PARAMETER_IDS = "No parameter IDs provided"
+    NO_PARAMETER_NAMES = "No parameter names provided"
+    PARAMETER_NAMES_NOT_RESOLVED = "Could not resolve any parameter names"
+    INVALID_INCLUDE_PARAMS = (
+        "None of the requested parameters are valid for this section"
+    )
+    EMPTY_INCLUDE_LIST = (
+        "Empty include list provided. Use None to fetch all parameters."
+    )
+
 
 # Time validation constants
 MIN_VALID_YEAR: Final[int] = 1900  # Reasonable minimum year for BSB-LAN devices
 MAX_VALID_YEAR: Final[int] = 2100  # Reasonable maximum year for BSB-LAN devices
-
-# Error messages for low-level parameter access
-NO_PARAMETER_IDS_ERROR_MSG: Final[str] = "No parameter IDs provided"
-NO_PARAMETER_NAMES_ERROR_MSG: Final[str] = "No parameter names provided"
-PARAMETER_NAMES_NOT_RESOLVED_ERROR_MSG: Final[str] = (
-    "Could not resolve any parameter names"
-)
-INVALID_INCLUDE_PARAMS_ERROR_MSG: Final[str] = (
-    "None of the requested parameters are valid for this section"
-)
-EMPTY_INCLUDE_LIST_ERROR_MSG: Final[str] = (
-    "Empty include list provided. Use None to fetch all parameters."
-)
 
 # Handle both ASCII and Unicode degree symbols
 TEMPERATURE_UNITS = {"°C", "°F", "&#176;C", "&#176;F", "&deg;C", "&deg;F"}

--- a/tests/test_api_initialization.py
+++ b/tests/test_api_initialization.py
@@ -10,8 +10,8 @@ import pytest
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_VERSION_ERROR_MSG,
     API_VERSIONS,
+    ErrorMsg,
 )
 from bsblan.exceptions import BSBLANError
 
@@ -23,7 +23,7 @@ async def test_initialize_api_data_no_api_version() -> None:
     bsblan = BSBLAN(config)
 
     # API version is None by default
-    with pytest.raises(BSBLANError, match=API_VERSION_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
         await bsblan._initialize_api_data()
 
 

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -17,10 +17,9 @@ import pytest
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_DATA_NOT_INITIALIZED_ERROR_MSG,
-    API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG,
     API_VERSIONS,
     APIConfig,
+    ErrorMsg,
 )
 from bsblan.exceptions import BSBLANError
 from bsblan.utility import APIValidator
@@ -86,7 +85,7 @@ async def test_validate_api_section_no_validator() -> None:
         # Ensure validator is None
         bsblan._api_validator = None  # type: ignore[assignment]
 
-        with pytest.raises(BSBLANError, match=API_VALIDATOR_NOT_INITIALIZED_ERROR_MSG):
+        with pytest.raises(BSBLANError, match=ErrorMsg.API_VALIDATOR_NOT_INITIALIZED):
             await bsblan._validate_api_section("device")
 
 
@@ -100,7 +99,7 @@ async def test_validate_api_section_no_api_data() -> None:
         bsblan._api_validator = APIValidator({})
         bsblan._api_data = None
 
-        with pytest.raises(BSBLANError, match=API_DATA_NOT_INITIALIZED_ERROR_MSG):
+        with pytest.raises(BSBLANError, match=ErrorMsg.API_DATA_NOT_INITIALIZED):
             await bsblan._validate_api_section("device")
 
 

--- a/tests/test_bsblan_edge_cases.py
+++ b/tests/test_bsblan_edge_cases.py
@@ -9,7 +9,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig
-from bsblan.constants import API_DATA_NOT_INITIALIZED_ERROR_MSG
+from bsblan.constants import ErrorMsg
 from bsblan.exceptions import BSBLANConnectionError, BSBLANError
 
 
@@ -137,5 +137,5 @@ async def test_initialize_api_data_none_after_init(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(BSBLAN, "__setattr__", mock_setattr)
 
-    with pytest.raises(BSBLANError, match=API_DATA_NOT_INITIALIZED_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.API_DATA_NOT_INITIALIZED):
         await bsblan._initialize_api_data()

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -13,7 +13,7 @@ import pytest
 from aresponses import Response, ResponsesMockServer
 
 from bsblan import BSBLAN, BSBLANConfig, State, StaticState
-from bsblan.constants import MULTI_PARAMETER_ERROR_MSG, build_api_config
+from bsblan.constants import ErrorMsg, build_api_config
 from bsblan.exceptions import BSBLANError, BSBLANInvalidParameterError
 from bsblan.utility import APIValidator
 
@@ -390,7 +390,7 @@ async def test_thermostat_circuit2_no_params(
 
     with pytest.raises(BSBLANError) as exc_info:
         await mock_bsblan_circuit.thermostat(circuit=2)
-    assert str(exc_info.value) == MULTI_PARAMETER_ERROR_MSG
+    assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER
 
 
 # --- Temperature range initialization tests ---

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -7,7 +7,7 @@ import pytest
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.constants import MULTI_PARAMETER_ERROR_MSG
+from bsblan.constants import ErrorMsg
 from bsblan.exceptions import BSBLANError
 
 
@@ -59,17 +59,17 @@ def test_validate_single_parameter() -> None:
     bsblan._validate_single_parameter(1, None, None, error_msg="Test error")
 
     # Test with no parameters
-    with pytest.raises(BSBLANError, match=MULTI_PARAMETER_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.MULTI_PARAMETER):
         bsblan._validate_single_parameter(
-            None, None, None, error_msg=MULTI_PARAMETER_ERROR_MSG
+            None, None, None, error_msg=ErrorMsg.MULTI_PARAMETER
         )
 
     # Test with multiple parameters
-    with pytest.raises(BSBLANError, match=MULTI_PARAMETER_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.MULTI_PARAMETER):
         bsblan._validate_single_parameter(
-            1, 2, None, error_msg=MULTI_PARAMETER_ERROR_MSG
+            1, 2, None, error_msg=ErrorMsg.MULTI_PARAMETER
         )
 
     # Test with all parameters
-    with pytest.raises(BSBLANError, match=MULTI_PARAMETER_ERROR_MSG):
-        bsblan._validate_single_parameter(1, 2, 3, error_msg=MULTI_PARAMETER_ERROR_MSG)
+    with pytest.raises(BSBLANError, match=ErrorMsg.MULTI_PARAMETER):
+        bsblan._validate_single_parameter(1, 2, 3, error_msg=ErrorMsg.MULTI_PARAMETER)

--- a/tests/test_dhw_time_switch.py
+++ b/tests/test_dhw_time_switch.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from bsblan import BSBLAN, BSBLANError, SetHotWaterParam
-from bsblan.constants import MULTI_PARAMETER_ERROR_MSG
+from bsblan.constants import ErrorMsg
 from bsblan.models import DHWTimeSwitchPrograms
 
 
@@ -125,7 +125,7 @@ async def test_set_dhw_time_program(mock_bsblan: BSBLAN) -> None:
         monday="13:00-14:00 ##:##-##:## ##:##-##:##",
         tuesday="06:00-08:00 17:00-20:00 ##:##-##:##",
     )
-    with pytest.raises(BSBLANError, match=MULTI_PARAMETER_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.MULTI_PARAMETER):
         await mock_bsblan.set_hot_water(
             SetHotWaterParam(dhw_time_programs=dhw_programs)
         )

--- a/tests/test_include_parameter.py
+++ b/tests/test_include_parameter.py
@@ -16,8 +16,7 @@ import pytest
 from bsblan import BSBLAN, BSBLANConfig, State, StaticState
 from bsblan.constants import (
     API_V3,
-    EMPTY_INCLUDE_LIST_ERROR_MSG,
-    INVALID_INCLUDE_PARAMS_ERROR_MSG,
+    ErrorMsg,
 )
 from bsblan.exceptions import BSBLANError
 from bsblan.utility import APIValidator
@@ -120,7 +119,7 @@ async def test_section_method_with_empty_include_list(
         with pytest.raises(BSBLANError) as exc_info:
             await method(include=[])
 
-        assert str(exc_info.value) == EMPTY_INCLUDE_LIST_ERROR_MSG
+        assert str(exc_info.value) == ErrorMsg.EMPTY_INCLUDE_LIST
         request_mock.assert_not_awaited()
 
 
@@ -160,7 +159,7 @@ async def test_section_method_with_invalid_params(
         with pytest.raises(BSBLANError) as exc_info:
             await method(include=["nonexistent_param"])
 
-        assert str(exc_info.value) == INVALID_INCLUDE_PARAMS_ERROR_MSG
+        assert str(exc_info.value) == ErrorMsg.INVALID_INCLUDE_PARAMS
         request_mock.assert_not_awaited()
 
 
@@ -520,7 +519,7 @@ async def test_hot_water_method_with_empty_include_list(
         with pytest.raises(BSBLANError) as exc_info:
             await method(include=[])
 
-        assert str(exc_info.value) == EMPTY_INCLUDE_LIST_ERROR_MSG
+        assert str(exc_info.value) == ErrorMsg.EMPTY_INCLUDE_LIST
         request_mock.assert_not_awaited()
 
 
@@ -571,5 +570,5 @@ async def test_hot_water_method_with_invalid_params(
         with pytest.raises(BSBLANError) as exc_info:
             await method(include=["nonexistent_param"])
 
-        assert str(exc_info.value) == INVALID_INCLUDE_PARAMS_ERROR_MSG
+        assert str(exc_info.value) == ErrorMsg.INVALID_INCLUDE_PARAMS
         request_mock.assert_not_awaited()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -14,7 +14,7 @@ from aresponses import ResponsesMockServer
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_VERSION_ERROR_MSG,
+    ErrorMsg,
 )
 from bsblan.exceptions import BSBLANError
 
@@ -95,7 +95,7 @@ async def test_api_version_error() -> None:
         # Force api_version to None to test error condition
         bsblan._api_version = None
 
-        with pytest.raises(BSBLANError, match=API_VERSION_ERROR_MSG):
+        with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
             await bsblan._initialize_api_data()
 
 

--- a/tests/test_set_hotwater.py
+++ b/tests/test_set_hotwater.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from bsblan import BSBLAN, BSBLANError, SetHotWaterParam
-from bsblan.constants import MULTI_PARAMETER_ERROR_MSG, NO_STATE_ERROR_MSG
+from bsblan.constants import ErrorMsg
 
 
 @pytest.mark.asyncio
@@ -44,7 +44,7 @@ async def test_set_hot_water(mock_bsblan: BSBLAN) -> None:
     )
 
     # Test setting multiple parameters (should raise an error)
-    with pytest.raises(BSBLANError, match=MULTI_PARAMETER_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.MULTI_PARAMETER):
         await mock_bsblan.set_hot_water(
             SetHotWaterParam(nominal_setpoint=60.0, reduced_setpoint=40.0)
         )
@@ -173,7 +173,7 @@ async def test_prepare_hot_water_state(mock_bsblan: BSBLAN) -> None:
 
     # Test preparing no parameters (should raise an error)
     params = SetHotWaterParam()
-    with pytest.raises(BSBLANError, match=NO_STATE_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.NO_STATE):
         mock_bsblan._prepare_hot_water_state(params)
 
     # Test preparing operating_mode

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.constants import API_VERSIONS, TEMPERATURE_RANGE_ERROR_MSG, APIConfig
+from bsblan.constants import API_VERSIONS, APIConfig, ErrorMsg
 from bsblan.exceptions import BSBLANError, BSBLANInvalidParameterError
 from bsblan.utility import APIValidator
 
@@ -27,7 +27,7 @@ async def test_validate_target_temperature_no_range() -> None:
     bsblan._initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
 
     # Temperature range is not initialized by default
-    with pytest.raises(BSBLANError, match=TEMPERATURE_RANGE_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.TEMPERATURE_RANGE):
         await bsblan._validate_target_temperature("22.0")
 
 

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -16,7 +16,7 @@ from aiohttp.web_request import Request
 from aresponses import Response, ResponsesMockServer
 
 from bsblan import BSBLAN, BSBLANConfig
-from bsblan.constants import MULTI_PARAMETER_ERROR_MSG
+from bsblan.constants import ErrorMsg
 from bsblan.exceptions import (
     BSBLANError,
     BSBLANInvalidParameterError,
@@ -191,4 +191,4 @@ async def test_no_parameters(mock_bsblan: BSBLAN) -> None:
     """Test calling thermostat without parameters."""
     with pytest.raises(BSBLANError) as exc_info:
         await mock_bsblan.thermostat()
-    assert str(exc_info.value) == MULTI_PARAMETER_ERROR_MSG
+    assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -7,7 +7,7 @@ import pytest
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.constants import API_VERSION_ERROR_MSG, FIRMWARE_VERSION_ERROR_MSG
+from bsblan.constants import ErrorMsg
 from bsblan.exceptions import BSBLANError, BSBLANVersionError
 from bsblan.models import Device
 
@@ -19,7 +19,7 @@ async def test_set_api_version_without_firmware() -> None:
     bsblan = BSBLAN(config)
 
     # Firmware version is None by default
-    with pytest.raises(BSBLANError, match=FIRMWARE_VERSION_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.FIRMWARE_VERSION):
         bsblan._set_api_version()
 
 
@@ -91,7 +91,7 @@ async def test_initialize_api_validator_no_api_version() -> None:
     bsblan = BSBLAN(config)
 
     # API version is None by default
-    with pytest.raises(BSBLANError, match=API_VERSION_ERROR_MSG):
+    with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
         await bsblan._initialize_api_validator()
 
 


### PR DESCRIPTION
This pull request refactors how error messages are managed and referenced throughout the `bsblan` codebase. Instead of using individual string constants for each error message, all error messages are now encapsulated in a new `ErrorMsg` class. All code that previously referenced the old constants has been updated to use the new class attributes, improving maintainability and consistency.

Key changes include:

**Error Message Refactoring:**

* Introduced a new `ErrorMsg` class in `constants.py` to centralize all error message strings, replacing the previous pattern of individual error message constants.
* Updated all references in `bsblan.py` to use `ErrorMsg.<ATTRIBUTE>` instead of the old error message constants, ensuring consistent error handling throughout the codebase. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L21-R38) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L261-R243) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L288-R270) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L338-R323) [[5]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L427-R409) [[6]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L471-R456) [[7]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L486-R468) [[8]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L595-R577) [[9]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L606-R588) [[10]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L696-R678) [[11]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L727-R709) [[12]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L741-R723) [[13]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L817-R799) [[14]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L841-R823) [[15]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L979-R974) [[16]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1174-R1156) [[17]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1250-R1232) [[18]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1264-R1246) [[19]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1356-R1345) [[20]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1532-R1514) [[21]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1564-R1546) [[22]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1614-R1596) [[23]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1649-R1631) [[24]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1747-R1739)

**Test Updates:**

* Modified tests to reference the new `ErrorMsg` class attributes instead of the old error message constants, ensuring tests remain valid and up to date. [[1]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL13-R14) [[2]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL26-R26) [[3]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L20-R22)

This refactor improves code clarity and makes it easier to manage and update error messages in the future.