### PR TITLE
Refactor parameter constants into configuration classes

### DIFF
--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -19,23 +19,11 @@ from yarl import URL
 
 from .constants import (
     API_VERSIONS,
-    CIRCUIT_HEATING_SECTIONS,
-    CIRCUIT_PROBE_PARAMS,
-    CIRCUIT_STATIC_SECTIONS,
-    CIRCUIT_STATUS_PARAMS,
-    CIRCUIT_THERMOSTAT_PARAMS,
-    DHW_TIME_PROGRAM_PARAMS,
-    HOT_WATER_CONFIG_PARAMS,
-    HOT_WATER_ESSENTIAL_PARAMS,
-    HOT_WATER_SCHEDULE_PARAMS,
-    INACTIVE_CIRCUIT_MARKER,
-    MAX_VALID_YEAR,
-    MIN_VALID_YEAR,
-    SETTABLE_HOT_WATER_PARAMS,
-    VALID_CIRCUITS,
-    VALID_HVAC_MODES,
     APIConfig,
+    CircuitConfig,
     ErrorMsg,
+    HotWaterParams,
+    Validation,
 )
 from .exceptions import (
     BSBLANAuthError,
@@ -186,7 +174,7 @@ class BSBLAN:
 
         """
         available: list[int] = []
-        for circuit, param_id in CIRCUIT_PROBE_PARAMS.items():
+        for circuit, param_id in CircuitConfig.PROBE_PARAMS.items():
             try:
                 response = await self._request(
                     params={"Parameter": param_id},
@@ -200,7 +188,7 @@ class BSBLAN:
                 # Inactive circuits either:
                 # - return value="0" and desc="---"
                 # - return an empty dict {} (param not supported)
-                status_id = CIRCUIT_STATUS_PARAMS[circuit]
+                status_id = CircuitConfig.STATUS_PARAMS[circuit]
                 status_resp = await self._request(
                     params={"Parameter": status_id},
                 )
@@ -216,7 +204,7 @@ class BSBLAN:
 
                 # value="0" + desc="---" means inactive
                 if (
-                    status_data.get("desc") == INACTIVE_CIRCUIT_MARKER
+                    status_data.get("desc") == CircuitConfig.INACTIVE_MARKER
                     and str(status_data.get("value", "")) == "0"
                 ):
                     logger.debug(
@@ -674,7 +662,7 @@ class BSBLAN:
             BSBLANInvalidParameterError: If the circuit number is invalid.
 
         """
-        if circuit not in VALID_CIRCUITS:
+        if circuit not in CircuitConfig.VALID:
             msg = ErrorMsg.INVALID_CIRCUIT.format(circuit)
             raise BSBLANInvalidParameterError(msg)
 
@@ -1012,7 +1000,7 @@ class BSBLAN:
         """
         self._validate_circuit(circuit)
         section: SectionLiteral = cast(
-            "SectionLiteral", CIRCUIT_HEATING_SECTIONS[circuit]
+            "SectionLiteral", CircuitConfig.HEATING_SECTIONS[circuit]
         )
         return await self._fetch_section_data(section, State, include)
 
@@ -1060,7 +1048,7 @@ class BSBLAN:
         """
         self._validate_circuit(circuit)
         section: SectionLiteral = cast(
-            "SectionLiteral", CIRCUIT_STATIC_SECTIONS[circuit]
+            "SectionLiteral", CircuitConfig.STATIC_SECTIONS[circuit]
         )
         return await self._fetch_section_data(section, StaticState, include)
 
@@ -1180,7 +1168,7 @@ class BSBLAN:
             dict[str, Any]: The prepared state for the thermostat.
 
         """
-        param_ids = CIRCUIT_THERMOSTAT_PARAMS[circuit]
+        param_ids = CircuitConfig.THERMOSTAT_PARAMS[circuit]
         state: dict[str, Any] = {}
         if target_temperature is not None:
             await self._validate_target_temperature(
@@ -1262,7 +1250,7 @@ class BSBLAN:
             BSBLANInvalidParameterError: If the HVAC mode is invalid.
 
         """
-        if hvac_mode not in VALID_HVAC_MODES:
+        if hvac_mode not in Validation.HVAC_MODES:
             raise BSBLANInvalidParameterError(str(hvac_mode))
 
     def _validate_time_format(self, time_value: str) -> None:
@@ -1276,7 +1264,7 @@ class BSBLAN:
 
         """
         try:
-            validate_time_format(time_value, MIN_VALID_YEAR, MAX_VALID_YEAR)
+            validate_time_format(time_value, Validation.MIN_YEAR, Validation.MAX_YEAR)
         except ValueError as err:
             raise BSBLANInvalidParameterError(str(err)) from err
 
@@ -1379,7 +1367,7 @@ class BSBLAN:
 
         """
         return await self._fetch_hot_water_data(
-            param_filter=HOT_WATER_ESSENTIAL_PARAMS,
+            param_filter=HotWaterParams.ESSENTIAL,
             model_class=HotWaterState,
             error_msg="No essential hot water parameters available",
             group_name="essential",
@@ -1419,7 +1407,7 @@ class BSBLAN:
 
         """
         return await self._fetch_hot_water_data(
-            param_filter=HOT_WATER_CONFIG_PARAMS,
+            param_filter=HotWaterParams.CONFIG,
             model_class=HotWaterConfig,
             error_msg="No hot water configuration parameters available",
             group_name="config",
@@ -1455,7 +1443,7 @@ class BSBLAN:
 
         """
         return await self._fetch_hot_water_data(
-            param_filter=HOT_WATER_SCHEDULE_PARAMS,
+            param_filter=HotWaterParams.SCHEDULE,
             model_class=HotWaterSchedule,
             error_msg="No hot water schedule parameters available",
             group_name="schedule",
@@ -1548,7 +1536,9 @@ class BSBLAN:
         # Invert DHW_TIME_PROGRAM_PARAMS to get day_name -> param_id mapping
         # Exclude standard_values as it's not a day of the week
         day_param_map = {
-            v: k for k, v in DHW_TIME_PROGRAM_PARAMS.items() if v != "standard_values"
+            v: k
+            for k, v in HotWaterParams.TIME_PROGRAMS.items()
+            if v != "standard_values"
         }
 
         for day_name, param_id in day_param_map.items():
@@ -1580,14 +1570,14 @@ class BSBLAN:
         state: dict[str, Any] = {}
 
         # Process all mapped parameters using constants
-        for param_id, attr_name in SETTABLE_HOT_WATER_PARAMS.items():
+        for param_id, attr_name in HotWaterParams.SETTABLE.items():
             value = getattr(params, attr_name)
             if value is not None:
                 state.update({"Parameter": param_id, "Value": str(value), "Type": "1"})
 
         # Process time programs if provided using constants
         if params.dhw_time_programs:
-            for param_id, attr_name in DHW_TIME_PROGRAM_PARAMS.items():
+            for param_id, attr_name in HotWaterParams.TIME_PROGRAMS.items():
                 value = getattr(params.dhw_time_programs, attr_name)
                 if value is not None:
                     state.update({"Parameter": param_id, "Value": value, "Type": "1"})

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -8,7 +8,6 @@ from typing import Final, TypedDict
 # Supported heating circuits (1-based)
 MIN_CIRCUIT: Final[int] = 1
 MAX_CIRCUIT: Final[int] = 2
-VALID_CIRCUITS: Final[set[int]] = {1, 2}
 
 
 # API Versions
@@ -127,39 +126,33 @@ V3_STATIC_VALUES_CIRCUIT2_EXTENSIONS: Final[dict[str, str]] = {
     "1016": "max_temp",
 }
 
-# Mapping from circuit number to section names
-CIRCUIT_HEATING_SECTIONS: Final[dict[int, str]] = {
-    1: "heating",
-    2: "heating_circuit2",
-}
 
-CIRCUIT_STATIC_SECTIONS: Final[dict[int, str]] = {
-    1: "staticValues",
-    2: "staticValues_circuit2",
-}
+# Circuit configuration
+class CircuitConfig:
+    """Circuit-related constants for BSBLAN."""
 
-# Mapping from circuit number to thermostat parameter IDs
-CIRCUIT_THERMOSTAT_PARAMS: Final[dict[int, dict[str, str]]] = {
-    1: {"target_temperature": "710", "hvac_mode": "700"},
-    2: {"target_temperature": "1010", "hvac_mode": "1000"},
-}
-
-# Parameter IDs used to probe whether a heating circuit exists on the device.
-# We query the operating mode (hvac_mode) for each circuit.
-CIRCUIT_PROBE_PARAMS: Final[dict[int, str]] = {
-    1: "700",
-    2: "1000",
-}
-
-# Status parameter IDs used as a secondary check for circuit availability.
-# Inactive circuits return value="0" and desc="---" for these parameters.
-CIRCUIT_STATUS_PARAMS: Final[dict[int, str]] = {
-    1: "8000",
-    2: "8001",
-}
-
-# Marker value returned by BSB-LAN for parameters on inactive circuits
-INACTIVE_CIRCUIT_MARKER: Final[str] = "---"
+    VALID: Final[set[int]] = {1, 2}
+    HEATING_SECTIONS: Final[dict[int, str]] = {
+        1: "heating",
+        2: "heating_circuit2",
+    }
+    STATIC_SECTIONS: Final[dict[int, str]] = {
+        1: "staticValues",
+        2: "staticValues_circuit2",
+    }
+    THERMOSTAT_PARAMS: Final[dict[int, dict[str, str]]] = {
+        1: {"target_temperature": "710", "hvac_mode": "700"},
+        2: {"target_temperature": "1010", "hvac_mode": "1000"},
+    }
+    PROBE_PARAMS: Final[dict[int, str]] = {
+        1: "700",
+        2: "1000",
+    }
+    STATUS_PARAMS: Final[dict[int, str]] = {
+        1: "8000",
+        2: "8001",
+    }
+    INACTIVE_MARKER: Final[str] = "---"
 
 
 def build_api_config(version: str) -> APIConfig:
@@ -208,8 +201,14 @@ API_VERSIONS: Final[dict[str, APIConfig]] = {
     "v3": API_V3,
 }
 
-# Valid HVAC mode values for validation
-VALID_HVAC_MODES: Final[set[int]] = {0, 1, 2, 3}
+
+# Validation constants
+class Validation:
+    """Validation-related constants for BSBLAN."""
+
+    HVAC_MODES: Final[set[int]] = {0, 1, 2, 3}
+    MIN_YEAR: Final[int] = 1900
+    MAX_YEAR: Final[int] = 2100
 
 
 class HVACActionCategory(IntEnum):
@@ -494,10 +493,6 @@ class ErrorMsg:
     )
 
 
-# Time validation constants
-MIN_VALID_YEAR: Final[int] = 1900  # Reasonable minimum year for BSB-LAN devices
-MAX_VALID_YEAR: Final[int] = 2100  # Reasonable maximum year for BSB-LAN devices
-
 # Handle both ASCII and Unicode degree symbols
 TEMPERATURE_UNITS = {"°C", "°F", "&#176;C", "&#176;F", "&deg;C", "&deg;F"}
 
@@ -572,88 +567,91 @@ UNIT_STATE_CLASS_MAP: Final[dict[str, str]] = {
     "s": "measurement",
 }
 
+
 # Hot Water Parameter Groups
-# Essential parameters for frequent monitoring
-HOT_WATER_ESSENTIAL_PARAMS: Final[set[str]] = {
-    param_id
-    for param_id, name in BASE_HOT_WATER_PARAMS.items()
-    if name
-    in {
-        "operating_mode",
-        "nominal_setpoint",
-        "release",
-        "dhw_actual_value_top_temperature",
-        "state_dhw_pump",
+class HotWaterParams:
+    """Hot water parameter group constants for BSBLAN."""
+
+    # Essential parameters for frequent monitoring
+    ESSENTIAL: Final[set[str]] = {
+        param_id
+        for param_id, name in BASE_HOT_WATER_PARAMS.items()
+        if name
+        in {
+            "operating_mode",
+            "nominal_setpoint",
+            "release",
+            "dhw_actual_value_top_temperature",
+            "state_dhw_pump",
+        }
     }
-}
 
-# Configuration parameters checked less frequently
-HOT_WATER_CONFIG_PARAMS: Final[set[str]] = {
-    param_id
-    for param_id, name in BASE_HOT_WATER_PARAMS.items()
-    if name
-    in {
-        "eco_mode_selection",
-        "nominal_setpoint_max",
-        "reduced_setpoint",
-        "dhw_charging_priority",
-        "operating_mode_changeover",
-        "legionella_function",
-        "legionella_function_setpoint",
-        "legionella_function_periodicity",
-        "legionella_function_day",
-        "legionella_function_time",
-        "legionella_function_dwelling_time",
-        "legionella_circulation_pump",
-        "legionella_circulation_temp_diff",
-        "dhw_circulation_pump_release",
-        "dhw_circulation_pump_cycling",
-        "dhw_circulation_setpoint",
+    # Configuration parameters checked less frequently
+    CONFIG: Final[set[str]] = {
+        param_id
+        for param_id, name in BASE_HOT_WATER_PARAMS.items()
+        if name
+        in {
+            "eco_mode_selection",
+            "nominal_setpoint_max",
+            "reduced_setpoint",
+            "dhw_charging_priority",
+            "operating_mode_changeover",
+            "legionella_function",
+            "legionella_function_setpoint",
+            "legionella_function_periodicity",
+            "legionella_function_day",
+            "legionella_function_time",
+            "legionella_function_dwelling_time",
+            "legionella_circulation_pump",
+            "legionella_circulation_temp_diff",
+            "dhw_circulation_pump_release",
+            "dhw_circulation_pump_cycling",
+            "dhw_circulation_setpoint",
+        }
     }
-}
 
-# Schedule parameters (time programs)
-HOT_WATER_SCHEDULE_PARAMS: Final[set[str]] = {
-    param_id
-    for param_id, name in BASE_HOT_WATER_PARAMS.items()
-    if name
-    in {
-        "dhw_time_program_monday",
-        "dhw_time_program_tuesday",
-        "dhw_time_program_wednesday",
-        "dhw_time_program_thursday",
-        "dhw_time_program_friday",
-        "dhw_time_program_saturday",
-        "dhw_time_program_sunday",
-        "dhw_time_program_standard_values",
+    # Schedule parameters (time programs)
+    SCHEDULE: Final[set[str]] = {
+        param_id
+        for param_id, name in BASE_HOT_WATER_PARAMS.items()
+        if name
+        in {
+            "dhw_time_program_monday",
+            "dhw_time_program_tuesday",
+            "dhw_time_program_wednesday",
+            "dhw_time_program_thursday",
+            "dhw_time_program_friday",
+            "dhw_time_program_saturday",
+            "dhw_time_program_sunday",
+            "dhw_time_program_standard_values",
+        }
     }
-}
 
-# Settable hot water parameters mapping (param_id -> attribute name)
-# Used by set_hot_water to map SetHotWaterParam attributes to BSB-LAN parameter IDs
-SETTABLE_HOT_WATER_PARAMS: Final[dict[str, str]] = {
-    "1610": "nominal_setpoint",
-    "1612": "reduced_setpoint",
-    "1614": "nominal_setpoint_max",
-    "1600": "operating_mode",
-    "1601": "eco_mode_selection",
-    "1630": "dhw_charging_priority",
-    "1645": "legionella_function_setpoint",
-    "1641": "legionella_function_periodicity",
-    "1642": "legionella_function_day",
-    "1644": "legionella_function_time",
-    "1646": "legionella_function_dwelling_time",
-    "1680": "operating_mode_changeover",
-}
+    # Settable parameters mapping (param_id -> attribute name)
+    SETTABLE: Final[dict[str, str]] = {
+        "1610": "nominal_setpoint",
+        "1612": "reduced_setpoint",
+        "1614": "nominal_setpoint_max",
+        "1600": "operating_mode",
+        "1601": "eco_mode_selection",
+        "1630": "dhw_charging_priority",
+        "1645": "legionella_function_setpoint",
+        "1641": "legionella_function_periodicity",
+        "1642": "legionella_function_day",
+        "1644": "legionella_function_time",
+        "1646": "legionella_function_dwelling_time",
+        "1680": "operating_mode_changeover",
+    }
 
-# DHW time program parameter mappings
-DHW_TIME_PROGRAM_PARAMS: Final[dict[str, str]] = {
-    "561": "monday",
-    "562": "tuesday",
-    "563": "wednesday",
-    "564": "thursday",
-    "565": "friday",
-    "566": "saturday",
-    "567": "sunday",
-    "576": "standard_values",
-}
+    # DHW time program parameter mappings
+    TIME_PROGRAMS: Final[dict[str, str]] = {
+        "561": "monday",
+        "562": "tuesday",
+        "563": "wednesday",
+        "564": "thursday",
+        "565": "friday",
+        "566": "saturday",
+        "567": "sunday",
+        "576": "standard_values",
+    }

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -8,10 +8,8 @@ from bsblan.constants import (
     API_V1,
     API_V3,
     BASE_HOT_WATER_PARAMS,
-    HOT_WATER_CONFIG_PARAMS,
-    HOT_WATER_ESSENTIAL_PARAMS,
-    HOT_WATER_SCHEDULE_PARAMS,
     HeatingCircuitStatus,
+    HotWaterParams,
     HVACActionCategory,
     build_api_config,
     get_hvac_action_category,
@@ -90,7 +88,7 @@ def test_pre_built_api_configurations(
 def test_hot_water_parameter_groups_completeness() -> None:
     """Test that hot water parameter groups cover all parameters."""
     all_grouped_params = (
-        HOT_WATER_ESSENTIAL_PARAMS | HOT_WATER_CONFIG_PARAMS | HOT_WATER_SCHEDULE_PARAMS
+        HotWaterParams.ESSENTIAL | HotWaterParams.CONFIG | HotWaterParams.SCHEDULE
     )
 
     # All BASE_HOT_WATER_PARAMS should be categorized into one of the groups
@@ -101,9 +99,9 @@ def test_hot_water_parameter_groups_completeness() -> None:
 @pytest.mark.parametrize(
     ("group1", "group2"),
     [
-        (HOT_WATER_ESSENTIAL_PARAMS, HOT_WATER_CONFIG_PARAMS),
-        (HOT_WATER_ESSENTIAL_PARAMS, HOT_WATER_SCHEDULE_PARAMS),
-        (HOT_WATER_CONFIG_PARAMS, HOT_WATER_SCHEDULE_PARAMS),
+        (HotWaterParams.ESSENTIAL, HotWaterParams.CONFIG),
+        (HotWaterParams.ESSENTIAL, HotWaterParams.SCHEDULE),
+        (HotWaterParams.CONFIG, HotWaterParams.SCHEDULE),
     ],
 )
 def test_hot_water_parameter_groups_no_overlap(
@@ -117,9 +115,9 @@ def test_hot_water_parameter_groups_no_overlap(
 @pytest.mark.parametrize(
     ("group", "expected_count"),
     [
-        (HOT_WATER_ESSENTIAL_PARAMS, 5),  # Current optimized count
-        (HOT_WATER_CONFIG_PARAMS, 16),  # Configuration parameters
-        (HOT_WATER_SCHEDULE_PARAMS, 8),  # Time program parameters
+        (HotWaterParams.ESSENTIAL, 5),  # Current optimized count
+        (HotWaterParams.CONFIG, 16),  # Configuration parameters
+        (HotWaterParams.SCHEDULE, 8),  # Time program parameters
     ],
 )
 def test_hot_water_parameter_groups_expected_counts(
@@ -133,9 +131,9 @@ def test_hot_water_parameter_groups_expected_counts(
 def test_hot_water_parameter_groups_total_count() -> None:
     """Test that total grouped parameters match base parameters."""
     total_grouped = (
-        len(HOT_WATER_ESSENTIAL_PARAMS)
-        + len(HOT_WATER_CONFIG_PARAMS)
-        + len(HOT_WATER_SCHEDULE_PARAMS)
+        len(HotWaterParams.ESSENTIAL)
+        + len(HotWaterParams.CONFIG)
+        + len(HotWaterParams.SCHEDULE)
     )
     assert total_grouped == len(BASE_HOT_WATER_PARAMS)
 


### PR DESCRIPTION
This pull request refactors how constants are organized and accessed in the `bsblan` codebase. The main improvement is the grouping of related constants into dedicated classes (`CircuitConfig`, `Validation`, and `HotWaterParams`) instead of using module-level variables. This change improves code clarity, maintainability, and encapsulation, and all usages throughout the codebase and tests have been updated accordingly.

**Refactoring and Encapsulation of Constants:**

* Introduced `CircuitConfig` class in `constants.py` to encapsulate all circuit-related constants, such as valid circuit numbers, section mappings, thermostat parameters, probe/status parameters, and inactive marker. All references to these constants in `bsblan.py` were updated to use the new class attributes. [[1]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL130-R155) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L22-R26) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L189-R177) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L203-R191) [[5]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L219-R207) [[6]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L677-R665) [[7]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1015-R1003) [[8]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1063-R1051) [[9]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1183-R1171)
* Introduced `Validation` class in `constants.py` to group validation-related constants such as valid HVAC modes and valid year ranges. All usages in `bsblan.py` now reference these via the class. [[1]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL211-R211) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1265-R1253) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1279-R1267)
* Introduced `HotWaterParams` class in `constants.py` for all hot water parameter groups and mappings (essential, config, schedule, settable, and time programs). All usages in `bsblan.py` and `test_constants.py` were updated to use this class. [[1]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdR570-R576) [[2]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL591-R590) [[3]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL616-R615) [[4]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL632-R632) [[5]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL650-R648) [[6]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L22-R26) [[7]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1382-R1370) [[8]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1422-R1410) [[9]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1458-R1446) [[10]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1551-R1541) [[11]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1583-R1580) [[12]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL11-R12) [[13]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL93-R91) [[14]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL104-R104) [[15]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL120-R120) [[16]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL136-R136)

**Test Updates:**

* Updated all references in `test_constants.py` to use the new `HotWaterParams` class attributes instead of the old module-level constants. [[1]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL11-R12) [[2]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL93-R91) [[3]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL104-R104) [[4]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL120-R120) [[5]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL136-R136)

These changes are purely organizational and do not alter any functional logic, but they make the codebase more modular and easier to maintain.