### PR TITLE
Skip temperature range validation for devices without min/max params

### DIFF
--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -1201,23 +1201,28 @@ class BSBLAN:
         """Validate the target temperature.
 
         This method lazy-loads the temperature range if not already initialized.
+        If the device does not provide min/max temperature parameters,
+        only validates that the value is a valid float.
 
         Args:
             target_temperature (str): The target temperature to validate.
             circuit: The heating circuit number (1 or 2).
 
         Raises:
-            BSBLANError: If the temperature range cannot be initialized.
             BSBLANInvalidParameterError: If the target temperature is invalid.
 
         """
+        # Validate it's a valid float first
+        try:
+            temp = float(target_temperature)
+        except ValueError as err:
+            raise BSBLANInvalidParameterError(target_temperature) from err
+
+        # Try to load temperature range for bounds checking
         if circuit == 1:
             # HC1 uses legacy fields for backwards compatibility
             if self._min_temp is None or self._max_temp is None:
                 await self._initialize_temperature_range(circuit)
-
-            if self._min_temp is None or self._max_temp is None:
-                raise BSBLANError(ErrorMsg.TEMPERATURE_RANGE)
 
             min_temp = self._min_temp
             max_temp = self._max_temp
@@ -1230,15 +1235,12 @@ class BSBLAN:
             min_temp = temp_range.get("min")
             max_temp = temp_range.get("max")
 
-            if min_temp is None or max_temp is None:
-                raise BSBLANError(ErrorMsg.TEMPERATURE_RANGE)
+        # Skip range validation if device doesn't provide min/max
+        if min_temp is None or max_temp is None:
+            return
 
-        try:
-            temp = float(target_temperature)
-            if not (min_temp <= temp <= max_temp):
-                raise BSBLANInvalidParameterError(target_temperature)
-        except ValueError as err:
-            raise BSBLANInvalidParameterError(target_temperature) from err
+        if not (min_temp <= temp <= max_temp):
+            raise BSBLANInvalidParameterError(target_temperature)
 
     def _validate_hvac_mode(self, hvac_mode: int) -> None:
         """Validate the HVAC mode.

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -332,7 +332,7 @@ async def test_thermostat_circuit2_invalid_temperature(
 async def test_thermostat_circuit2_no_temp_range(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:
-    """Test error when HC2 temp range not available."""
+    """Test thermostat passes through when HC2 temp range not available."""
     # Set HC2 as initialized but with None range
     mock_bsblan_circuit._circuit_temp_ranges[2] = {
         "min": None,
@@ -340,11 +340,13 @@ async def test_thermostat_circuit2_no_temp_range(
     }
     mock_bsblan_circuit._circuit_temp_initialized.add(2)
 
-    with pytest.raises(BSBLANError, match="Temperature range"):
-        await mock_bsblan_circuit.thermostat(
-            target_temperature="20",
-            circuit=2,
-        )
+    # Should pass through without range validation when min/max are None
+    mock_bsblan_circuit._request = AsyncMock(return_value={"status": "success"})
+    await mock_bsblan_circuit.thermostat(
+        target_temperature="20",
+        circuit=2,
+    )
+    mock_bsblan_circuit._request.assert_awaited_once()
 
 
 # --- Validation tests ---

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -9,26 +9,25 @@ import pytest
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.constants import API_VERSIONS, APIConfig, ErrorMsg
+from bsblan.constants import API_VERSIONS, APIConfig
 from bsblan.exceptions import BSBLANError, BSBLANInvalidParameterError
 from bsblan.utility import APIValidator
 
 
 @pytest.mark.asyncio
 async def test_validate_target_temperature_no_range() -> None:
-    """Test validating target temperature with temperature range not initialized."""
+    """Test validating target temperature when device has no min/max params."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Mock _initialize_temperature_range to do nothing (simulate failure)
+    # Mock _initialize_temperature_range to do nothing (simulate no min/max)
     async def mock_init_temp_range(circuit: int = 1) -> None:
         pass
 
     bsblan._initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
 
-    # Temperature range is not initialized by default
-    with pytest.raises(BSBLANError, match=ErrorMsg.TEMPERATURE_RANGE):
-        await bsblan._validate_target_temperature("22.0")
+    # Should pass through without error when min/max are not available
+    await bsblan._validate_target_temperature("22.0")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request updates the target temperature validation logic to better handle devices that do not provide minimum or maximum temperature parameters. Instead of raising an error when min/max are unavailable, the code now only checks that the input is a valid float. The relevant tests have also been updated to reflect this new behavior.

**Validation logic improvements:**

* Updated `_validate_target_temperature` in `bsblan.py` to skip min/max range validation if the device does not provide these parameters, only ensuring the value is a valid float. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R1204-L1221) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R1238-L1241)

**Test updates:**

* Modified tests in `test_circuit.py` and `test_temperature_validation.py` to expect successful validation (no exception) when min/max temperature parameters are missing, rather than raising an error. [[1]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L335-R349) [[2]](diffhunk://#diff-4c2df41b90a609250317c411aacea720d54de5ad37f09a2a0a56b4cbc4d0829bL12-R29)