### PR TITLE
Fix thermostat circuit test parameter assertions

### DIFF
--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -345,7 +345,10 @@ async def test_thermostat_circuit2_no_temp_range(
         target_temperature="20",
         circuit=2,
     )
-    mock_bsblan_circuit._request.assert_awaited_once()
+    mock_bsblan_circuit._request.assert_awaited_once_with(
+        base_path="/JS",
+        data={"Parameter": "1010", "Value": "20", "Type": "1"},
+    )
 
 
 # --- Validation tests ---


### PR DESCRIPTION
This pull request makes a targeted improvement to the test coverage for the thermostat circuit functionality. Specifically, it enhances the assertion in `test_thermostat_circuit2_no_temp_range` to verify that the `_request` method is called with the correct parameters, ensuring more precise validation of the code's behavior.

Test coverage improvements:

* [`tests/test_circuit.py`](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L348-R351): Updated the assertion in `test_thermostat_circuit2_no_temp_range` to check that `mock_bsblan_circuit._request` is called with the expected arguments (`base_path="/JS"` and the correct data payload), rather than just being awaited.