### PR TITLE
fix: add contents:read permission to Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.default_branch == github.ref_name
     permissions:
+      contents: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Build Status][build-shield]][build]
 [![Code Coverage][codecov-shield]][codecov]
 [![Quality Gate Status][sonarcloud-shield]][sonarcloud]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard]
 
 [![Buy me a coffee][buymeacoffee-shield]][buymeacoffee]
 
@@ -233,5 +234,7 @@ SOFTWARE.
 [releases-shield]: https://img.shields.io/github/v/release/liudger/python-bsblan.svg
 [releases]: https://github.com/liudger/python-bsblan/releases
 [semver]: http://semver.org/spec/v2.0.0.html
+[scorecard-shield]: https://api.scorecard.dev/projects/github.com/liudger/python-bsblan/badge
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/liudger/python-bsblan
 [sonarcloud-shield]: https://sonarcloud.io/api/project_badges/measure?project=liudger_python-bsblan&metric=alert_status
 [sonarcloud]: https://sonarcloud.io/summary/new_code?id=liudger_python-bsblan


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/scorecard.yml` workflow by adding explicit `contents: read` permission. This clarifies the permissions required for the workflow to run successfully.