### PR TITLE
Move write permissions to job-level in workflows

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -9,12 +9,13 @@ on:
       - synchronize
       - reopened
 
-permissions:
-  pull-requests: write
+permissions: read-all
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: >-
       github.actor == 'renovate[bot]' &&
       github.actor_id == '29139614' &&

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,15 +11,16 @@ on:
   schedule:
     - cron: "30 1 * * 0"
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: read-all
 
 jobs:
   codeql:
     name: Scanning
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -10,14 +10,15 @@ on:
       - .github/labels.yml
   workflow_dispatch:
 
-permissions:
-  contents: read
-  issues: write
+permissions: read-all
 
 jobs:
   labels:
     name: ♻️ Sync labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -7,14 +7,15 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   lock:
     name: 🔒 Lock closed issues and PRs
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       # yamllint disable-line rule:line-length
       - uses: dessant/lock-threads@f5f995c727ac99a91dec92781a8e34e7c839a65e # v6.0.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -23,15 +23,16 @@ on:
           - alpha
           - rc
 
-permissions:
-  contents: write
-  issues: read
-  pull-requests: read
+permissions: read-all
 
 jobs:
   update_release_draft:
     name: ✏️ Draft release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
     steps:
       - name: 🚀 Run Release Drafter
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
     types:
       - published
 
+permissions: read-all
+
 env:
   DEFAULT_PYTHON: "3.13"
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,14 +7,15 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   stale:
     name: 🧹 Clean up stale issues and PRs
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: 🚀 Run stale
         uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0


### PR DESCRIPTION
Scorecard Token-Permissions check requires that write permissions are scoped to individual jobs, not at the workflow top-level.

Affected workflows:
- release.yaml: add top-level permissions: read-all
- release-drafter.yaml: move contents:write to job level
- codeql.yaml: move security-events:write to job level
- labels.yaml: move issues:write to job level
- lock.yaml: move issues/pull-requests:write to job level
- stale.yaml: move issues/pull-requests:write to job level
- auto-approve-renovate.yml: move pull-requests:write to job level