### PR TITLE
fix: update codeql-action to v4.35.2 and add SCORECARD_TOKEN

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,6 +27,6 @@ jobs:
         with:
           persist-credentials: false
       - name: 🏗 Initialize CodeQL
-        uses: github/codeql-action/init@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       - name: 🚀 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers
           #   - Allows the repository to include the Scorecard badge.
@@ -65,6 +66,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       - name: "Upload to code-scanning"
         # yamllint disable-line rule:line-length
-        uses: github/codeql-action/upload-sarif@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The pinned SHA for github/codeql-action was flagged as an 'imposter commit' by the scorecard webapp, causing publish_results to fail with: 'imposter commit: 0e9f55954318745b37b7933c693bc093f7336125 does not belong to github/codeql-action/upload-sarif'

Updated to v4.35.2 (95e58e9a) which is a valid release commit. Also added repo_token input using SCORECARD_TOKEN secret for the Branch-Protection check.