### PR TITLE
fix: improve OpenSSF Scorecard score

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -65,6 +65,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
       - name: 🏗 Install NPM dependencies
-        run: npm install
+        run: npm ci
       - name: 🚀 Run prettier
         run: uv run prek run prettier --all-files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
       name: release
       url: https://pypi.org/p/python-bsblan
     permissions:
+      attestations: write
       contents: write
       id-token: write
     steps:
@@ -48,6 +49,10 @@ jobs:
           sed -i '0,/version = ".*"/{s/version = ".*"/version = "'"${version}"'"/}' pyproject.toml
       - name: 🏗 Build package
         run: uv build
+      - name: 🔏 Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ./dist/*
       - name: 🚀 Publish to PyPi
         uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
         with:


### PR DESCRIPTION
- Use npm ci instead of npm install in linting workflow (Pinned-Dependencies)
- Add SLSA build provenance attestation to release workflow (Signed-Releases)
- Add attestations:write permission for provenance generation