### PR TITLE
Add auto-generated API documentation and GitHub Pages deployment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,8 +84,14 @@ Parameters are identified by numeric IDs and mapped to readable names in `consta
    ```python
    async def set_hot_water(
        self,
-       legionella_function_setpoint: float | None = None,
+       params: SetHotWaterParam,
    ) -> None:
+   ```
+   And add the field to `SetHotWaterParam` in `models.py`:
+   ```python
+   @dataclass
+   class SetHotWaterParam:
+       legionella_function_setpoint: float | None = None
    ```
 
 4. **Add tests in `tests/test_*.py`**
@@ -149,9 +155,11 @@ Each parameter returns an `EntityInfo[T]` (generic `BaseModel`) with:
 
 ### Client Usage
 ```python
-async with BSBLAN(host="192.168.1.100") as client:
+from bsblan import BSBLAN, BSBLANConfig, SetHotWaterParam
+
+async with BSBLAN(BSBLANConfig(host="192.168.1.100")) as client:
     state = await client.state()
-    await client.set_hot_water(nominal_setpoint=55.0)
+    await client.set_hot_water(SetHotWaterParam(nominal_setpoint=55.0))
 ```
 
 ### Lazy Loading Architecture
@@ -199,7 +207,9 @@ This prevents duplicate network requests when concurrent calls access the same s
 @pytest.mark.asyncio
 async def test_set_hot_water(mock_bsblan: BSBLAN) -> None:
     """Test setting BSBLAN hot water state."""
-    await mock_bsblan.set_hot_water(nominal_setpoint=60.0)
+    await mock_bsblan.set_hot_water(
+        SetHotWaterParam(nominal_setpoint=60.0)
+    )
     mock_bsblan._request.assert_awaited_with(
         base_path="/JS",
         data={"Parameter": "1610", "Value": "60.0", "Type": "1"},

--- a/.github/skills/bsblan-parameters/SKILL.md
+++ b/.github/skills/bsblan-parameters/SKILL.md
@@ -105,7 +105,9 @@ Create tests in `tests/test_*.py`:
 @pytest.mark.asyncio
 async def test_set_hot_water(mock_bsblan: BSBLAN) -> None:
     """Test setting BSBLAN hot water state."""
-    await mock_bsblan.set_hot_water(nominal_setpoint=60.0)
+    await mock_bsblan.set_hot_water(
+        SetHotWaterParam(nominal_setpoint=60.0)
+    )
     mock_bsblan._request.assert_awaited_with(
         base_path="/JS",
         data={"Parameter": "1610", "Value": "60.0", "Type": "1"},

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,60 @@
+---
+name: Documentation
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  DEFAULT_PYTHON: "3.13"
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 🏗 Set up uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        with:
+          enable-cache: true
+      - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: 🏗 Install dependencies
+        run: uv sync --group docs
+      - name: 🏗 Build documentation
+        run: uv run mkdocs build --strict
+      - name: 📤 Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: 🚀 Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ node_modules/
 
 # Deepcode AI
 .dccache
+
+# MkDocs
+site/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint test coverage help
+.PHONY: setup lint test coverage docs docs-serve help
 
 .DEFAULT_GOAL := help
 
@@ -18,3 +18,9 @@ test: ## Run tests
 
 coverage: ## Run tests with coverage report
 	uv run pytest --cov=src/bsblan --cov-report=term-missing
+
+docs: ## Build documentation
+	uv run mkdocs build --strict
+
+docs-serve: ## Serve documentation locally
+	uv run mkdocs serve

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Quality Gate Status][sonarcloud-shield]][sonarcloud]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard]
 
+[![Documentation][docs-shield]][docs]
 [![Buy me a coffee][buymeacoffee-shield]][buymeacoffee]
 
 Asynchronous Python client for BSBLan.
@@ -21,96 +22,35 @@ This package allows you to control and monitor a BSBLan device
 programmatically. It is mainly created to allow third-party programs to automate
 the behavior of [BSBLan][bsblanmodule].
 
+**[Full documentation](https://liudger.github.io/python-bsblan)**
+
 ## Installation
 
 ```bash
 pip install python-bsblan
 ```
 
-## Usage
+## Quick start
 
 ```python
-# pylint: disable=W0621
-"""Asynchronous Python client for BSBLan."""
-
 import asyncio
-import os
-
-from bsblan import BSBLAN, BSBLANConfig, Device, Info, Sensor, State, StaticState
-
-
-async def print_state(state: State) -> None:
-    """Print the current state of the BSBLan device."""
-    print(f"HVAC Action: {state.hvac_action.desc}")
-    print(f"HVAC Mode: {state.hvac_mode.desc}")
-    print(f"Current Temperature: {state.current_temperature.value}")
-
-
-async def print_sensor(sensor: Sensor) -> None:
-    """Print sensor information from the BSBLan device."""
-    print(f"Outside Temperature: {sensor.outside_temperature.value}")
-
-
-async def print_device_info(device: Device, info: Info) -> None:
-    """Print device and general information."""
-    print(f"Device Name: {device.name}")
-    print(f"Version: {device.version}")
-    print(f"Device Identification: {info.device_identification.value}")
-
-
-async def print_static_state(static_state: StaticState) -> None:
-    """Print static state information."""
-    print(f"Min Temperature: {static_state.min_temp.value}")
-    print(f"Max Temperature: {static_state.max_temp.value}")
-
+from bsblan import BSBLAN, BSBLANConfig
 
 async def main() -> None:
-    """Show example on controlling your BSBLan device.
-
-    Options:
-    - passkey (http://url/"passkey"/) if your device is setup for passkey authentication
-    - username and password if your device is setup for username/password authentication
-
-    """
-    # Create a configuration object
-    config = BSBLANConfig(
-        host="192.0.2.1",
-        passkey=None,
-        username=os.getenv("USERNAME"),  # Compliant
-        password=os.getenv("PASSWORD"),  # Compliant
-    )
-
-    # Initialize BSBLAN with the configuration object
-    async with BSBLAN(config) as bsblan:
-        # Get and print state
-        state: State = await bsblan.state()
-        await print_state(state)
+    config = BSBLANConfig(host="192.168.1.100")
+    async with BSBLAN(config) as client:
+        # Read current state
+        state = await client.state()
+        print(f"Current temperature: {state.current_temperature.value}")
 
         # Set thermostat temperature
-        print("\nSetting temperature to 18°C")
-        await bsblan.thermostat(target_temperature="18")
+        await client.thermostat(target_temperature="21.5")
 
-        # Set HVAC mode (using raw integer: 0=off, 1=auto, 2=eco, 3=heat)
-        print("Setting HVAC mode to heat")
-        await bsblan.thermostat(hvac_mode=3)
-
-        # Get and print sensor information
-        sensor: Sensor = await bsblan.sensor()
-        await print_sensor(sensor)
-
-        # Get and print device and general info
-        device: Device = await bsblan.device()
-        info: Info = await bsblan.info()
-        await print_device_info(device, info)
-
-        # Get and print static state
-        static_state: StaticState = await bsblan.static_values()
-        await print_static_state(static_state)
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
+
+For more examples, including hot water control, multi-circuit support, and
+authentication setup, see the [Getting Started][docs-getting-started] guide.
 
 ## Changelog & Releases
 
@@ -159,12 +99,14 @@ make setup
 A `Makefile` is provided for common development tasks. Run `make help` to
 see all available targets:
 
-| Command         | Description                          |
-|-----------------|--------------------------------------|
-| `make setup`    | Install dev dependencies & git hooks |
-| `make lint`     | Run all pre-commit hooks             |
-| `make test`     | Run tests                            |
-| `make coverage` | Run tests with coverage report       |
+| Command            | Description                          |
+|--------------------|--------------------------------------|
+| `make setup`       | Install dev dependencies & git hooks |
+| `make lint`        | Run all pre-commit hooks             |
+| `make test`        | Run tests                            |
+| `make coverage`    | Run tests with coverage report       |
+| `make docs`        | Build documentation                  |
+| `make docs-serve`  | Serve documentation locally          |
 
 As this repository uses [prek][prek] (a faster, Rust-based drop-in replacement
 for pre-commit), all changes are linted and tested with each commit. You can
@@ -215,6 +157,9 @@ SOFTWARE.
 [bsblanmodule]: https://github.com/fredlcore/bsb_lan
 [build-shield]: https://github.com/liudger/python-bsblan/actions/workflows/tests.yaml/badge.svg
 [build]: https://github.com/liudger/python-bsblan/actions
+[docs]: https://liudger.github.io/python-bsblan
+[docs-getting-started]: https://liudger.github.io/python-bsblan/getting-started/
+[docs-shield]: https://img.shields.io/badge/docs-GitHub%20Pages-blue
 [buymeacoffee-shield]: https://www.buymeacoffee.com/assets/img/guidelines/download-assets-sm-2.svg
 [buymeacoffee]: https://www.buymeacoffee.com/liudger
 [codecov-shield]: https://codecov.io/gh/liudger/python-bsblan/branch/main/graph/badge.svg?token=ypos87GGxv

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -1,0 +1,33 @@
+# Client
+
+The main entry point for interacting with BSB-LAN devices.
+
+## BSBLAN
+
+::: bsblan.BSBLAN
+    options:
+      show_bases: false
+      members:
+        - __init__
+        - initialize
+        - get_available_circuits
+        - state
+        - sensor
+        - static_values
+        - device
+        - info
+        - time
+        - set_time
+        - thermostat
+        - hot_water_state
+        - hot_water_config
+        - hot_water_schedule
+        - set_hot_water
+        - set_hot_water_schedule
+        - reset_validation
+
+## BSBLANConfig
+
+::: bsblan.BSBLANConfig
+    options:
+      show_bases: false

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -24,7 +24,6 @@ The main entry point for interacting with BSB-LAN devices.
         - hot_water_schedule
         - set_hot_water
         - set_hot_water_schedule
-        - reset_validation
 
 ## BSBLANConfig
 

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -1,0 +1,29 @@
+# Constants
+
+Enumerations and mappings used by the library.
+
+## Enumerations
+
+### HeatingCircuitStatus
+
+::: bsblan.HeatingCircuitStatus
+
+### HVACActionCategory
+
+::: bsblan.HVACActionCategory
+
+## Helper functions
+
+### get_hvac_action_category
+
+::: bsblan.get_hvac_action_category
+
+## Unit mappings
+
+### UNIT_DEVICE_CLASS_MAP
+
+::: bsblan.UNIT_DEVICE_CLASS_MAP
+
+### UNIT_STATE_CLASS_MAP
+
+::: bsblan.UNIT_STATE_CLASS_MAP

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,15 @@
+# Exceptions
+
+Custom exceptions raised by the library.
+
+## BSBLANError
+
+::: bsblan.BSBLANError
+
+## BSBLANConnectionError
+
+::: bsblan.BSBLANConnectionError
+
+## BSBLANAuthError
+
+::: bsblan.BSBLANAuthError

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,77 @@
+# Models
+
+Data models for BSB-LAN API responses.
+
+## Core types
+
+### EntityInfo
+
+::: bsblan.EntityInfo
+
+### EntityValue
+
+::: bsblan.EntityValue
+
+## Heating
+
+### State
+
+::: bsblan.State
+
+### StaticState
+
+::: bsblan.StaticState
+
+### Sensor
+
+::: bsblan.Sensor
+
+## Hot water
+
+### HotWaterState
+
+::: bsblan.HotWaterState
+
+### HotWaterConfig
+
+::: bsblan.HotWaterConfig
+
+### HotWaterSchedule
+
+::: bsblan.HotWaterSchedule
+
+### SetHotWaterParam
+
+::: bsblan.SetHotWaterParam
+
+## Schedules
+
+### DHWSchedule
+
+::: bsblan.DHWSchedule
+
+### DHWTimeSwitchPrograms
+
+::: bsblan.DHWTimeSwitchPrograms
+
+### DaySchedule
+
+::: bsblan.DaySchedule
+
+### TimeSlot
+
+::: bsblan.TimeSlot
+
+## Device
+
+### Device
+
+::: bsblan.Device
+
+### Info
+
+::: bsblan.Info
+
+### DeviceTime
+
+::: bsblan.DeviceTime

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,91 @@
+# Getting Started
+
+## Installation
+
+```bash
+pip install python-bsblan
+```
+
+## Configuration
+
+Create a `BSBLANConfig` object with your device connection details:
+
+```python
+from bsblan import BSBLAN, BSBLANConfig
+
+config = BSBLANConfig(
+    host="192.168.1.100",
+    passkey=None,           # Set if your device uses passkey auth
+    username=None,          # Set for username/password auth
+    password=None,
+)
+```
+
+!!! warning "Security"
+    Never hard-code credentials in your source code. Use environment variables
+    or a secrets manager instead.
+
+    ```python
+    import os
+
+    config = BSBLANConfig(
+        host=os.getenv("BSBLAN_HOST", "192.168.1.100"),
+        username=os.getenv("BSBLAN_USERNAME"),
+        password=os.getenv("BSBLAN_PASSWORD"),
+    )
+    ```
+
+## Basic usage
+
+```python
+import asyncio
+from bsblan import BSBLAN, BSBLANConfig
+
+async def main() -> None:
+    config = BSBLANConfig(host="192.168.1.100")
+    async with BSBLAN(config) as client:
+        # Read current heating state
+        state = await client.state()
+        print(f"HVAC Mode: {state.hvac_mode.desc}")
+        print(f"Current Temp: {state.current_temperature.value}")
+
+        # Read sensor data
+        sensor = await client.sensor()
+        print(f"Outside Temp: {sensor.outside_temperature.value}")
+
+        # Set thermostat
+        await client.thermostat(target_temperature="21.5")
+
+        # Get device info
+        device = await client.device()
+        print(f"Device: {device.name} v{device.version}")
+
+asyncio.run(main())
+```
+
+## Hot water control
+
+```python
+async with BSBLAN(config) as client:
+    # Read hot water state
+    hw_state = await client.hot_water_state()
+    print(f"DHW Mode: {hw_state.operating_mode.desc}")
+
+    # Read hot water configuration
+    hw_config = await client.hot_water_config()
+
+    # Set hot water temperature
+    await client.set_hot_water(nominal_setpoint=55.0)
+```
+
+## Multi-circuit support
+
+```python
+async with BSBLAN(config) as client:
+    # Get available heating circuits
+    circuits = await client.get_available_circuits()
+    print(f"Available circuits: {circuits}")
+
+    # Read state for a specific circuit
+    state = await client.state(circuit=2)
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,8 @@ asyncio.run(main())
 ## Hot water control
 
 ```python
+from bsblan import SetHotWaterParam
+
 async with BSBLAN(config) as client:
     # Read hot water state
     hw_state = await client.hot_water_state()
@@ -75,7 +77,7 @@ async with BSBLAN(config) as client:
     hw_config = await client.hot_water_config()
 
     # Set hot water temperature
-    await client.set_hot_water(nominal_setpoint=55.0)
+    await client.set_hot_water(SetHotWaterParam(nominal_setpoint=55.0))
 ```
 
 ## Multi-circuit support

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# python-bsblan
+
+Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) devices.
+
+## Features
+
+- Async/await support using `aiohttp`
+- Read heating state, sensor data, and device information
+- Control thermostat settings and hot water parameters
+- Fully typed with PEP 561 support
+- Automatic API version detection (v1/v3)
+- Lazy loading with per-section validation
+
+## Quick example
+
+```python
+import asyncio
+from bsblan import BSBLAN, BSBLANConfig
+
+async def main() -> None:
+    config = BSBLANConfig(host="192.168.1.100")
+    async with BSBLAN(config) as client:
+        state = await client.state()
+        print(f"Current temperature: {state.current_temperature.value}")
+
+asyncio.run(main())
+```
+
+## Navigation
+
+- [Getting Started](getting-started.md) — Installation, configuration, and usage
+- [API Reference](api/client.md) — Full API documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,69 @@
+---
+site_name: python-bsblan
+site_url: https://liudger.github.io/python-bsblan
+site_description: Asynchronous Python client for BSB-LAN devices
+site_author: Willem-Jan van Rootselaar
+repo_url: https://github.com/liudger/python-bsblan
+repo_name: liudger/python-bsblan
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - navigation.sections
+    - navigation.expand
+    - search.highlight
+    - search.suggest
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - API Reference:
+      - Client: api/client.md
+      - Models: api/models.md
+      - Exceptions: api/exceptions.md
+      - Constants: api/constants.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            merge_init_into_class: true
+            show_signature_annotations: true
+            separate_signature: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/liudger/python-bsblan"
 Repository = "https://github.com/liudger/python-bsblan"
-Documentation = "https://github.com/liudger/python-bsblan"
+Documentation = "https://liudger.github.io/python-bsblan"
 "Bug Tracker" = "https://github.com/liudger/python-bsblan/issues"
 Changelog = "https://github.com/liudger/python-bsblan/releases"
 
@@ -210,4 +210,8 @@ dev = [
     "vulture==2.16",
     "yamllint==1.38.0",
     "zeroconf>=0.148.0",
+]
+docs = [
+    "mkdocs-material>=9.6",
+    "mkdocstrings[python]>=0.29",
 ]


### PR DESCRIPTION
This pull request adds a full documentation system to the project, including automated building and deployment of docs to GitHub Pages, as well as new Makefile targets and project dependencies for documentation. It introduces a comprehensive MkDocs configuration with Material theme, API reference pages using mkdocstrings, and user guides. The documentation can now be built and served locally, and is automatically published on pushes to `main`.

**Documentation system and automation:**

* Added `.github/workflows/docs.yaml` GitHub Actions workflow to build documentation with MkDocs and deploy it to GitHub Pages on every push to `main`.
* Added `mkdocs.yml` configuration using the Material theme, navigation, plugins (including `mkdocstrings` for API docs), and markdown extensions.
* Updated `pyproject.toml` to add `docs` extra dependencies for documentation building (`mkdocs-material`, `mkdocstrings`).
* Updated project documentation URL to point to the new GitHub Pages site.

**Makefile improvements:**

* Added `docs` and `docs-serve` targets to the `Makefile` for building and serving documentation locally. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R21-R26)

**Documentation content:**

* Added new documentation pages under `docs/`:
  - [`index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R1-R32): Project overview and navigation.
  - [`getting-started.md`](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R1-R91): Installation, configuration, and usage examples.
  - `api/client.md`, `api/models.md`, `api/exceptions.md`, `api/constants.md`: API reference generated via mkdocstrings. [[1]](diffhunk://#diff-616575a1094cd358184f51f61431ae15ee7680ffd73d506e0518d733272a2893R1-R33) [[2]](diffhunk://#diff-67edb934bfe37fbd614c06ff6b9d607332fb675e88e67a4736910c49b6ad58fcR1-R77) [[3]](diffhunk://#diff-9c19bbc34c90f770a82ca120c9c7b4f413d3ef23bbbab0ed043b14bfa10b67bfR1-R15) [[4]](diffhunk://#diff-d8888c43bca5401000dcd4a49f0bc1b3ef421edf5d3dc31e47b378807ea7980fR1-R29)