### PR TITLE
fix: correct actions/deploy-pages SHA for v4.0.5

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for documentation deployment. The change updates the commit hash for the `actions/deploy-pages` action to a new version, while keeping the version tag at v4.0.5.