### PR TITLE
Add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Code Coverage][codecov-shield]][codecov]
 [![Quality Gate Status][sonarcloud-shield]][sonarcloud]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard]
+[![OpenSSF Best Practices][bestpractices-shield]][bestpractices]
 
 [![Documentation][docs-shield]][docs]
 [![Buy me a coffee][buymeacoffee-shield]][buymeacoffee]
@@ -181,5 +182,7 @@ SOFTWARE.
 [semver]: http://semver.org/spec/v2.0.0.html
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/liudger/python-bsblan/badge
 [scorecard]: https://scorecard.dev/viewer/?uri=github.com/liudger/python-bsblan
+[bestpractices-shield]: https://www.bestpractices.dev/projects/12561/badge
+[bestpractices]: https://www.bestpractices.dev/projects/12561
 [sonarcloud-shield]: https://sonarcloud.io/api/project_badges/measure?project=liudger_python-bsblan&metric=alert_status
 [sonarcloud]: https://sonarcloud.io/summary/new_code?id=liudger_python-bsblan

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@
 [![Quality Gate Status][sonarcloud-shield]][sonarcloud]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard]
 [![OpenSSF Best Practices][bestpractices-shield]][bestpractices]
-
 [![Documentation][docs-shield]][docs]
-[![Buy me a coffee][buymeacoffee-shield]][buymeacoffee]
 
 Asynchronous Python client for BSBLan.
 
@@ -154,6 +152,10 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+[![Buy me a coffee][buymeacoffee-shield]][buymeacoffee]
 
 [bsblanmodule]: https://github.com/fredlcore/bsb_lan
 [build-shield]: https://github.com/liudger/python-bsblan/actions/workflows/tests.yaml/badge.svg


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by adding a badge for OpenSSF Best Practices. This helps highlight the project's adherence to security and best practice standards.

- Documentation improvements:
  * Added the OpenSSF Best Practices badge and its associated references to the `README.md` to showcase compliance with best practices. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R185-R186)