### PR TITLE
Update GitHub Actions and project stage badge to stable

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: 🏗 Build documentation
         run: uv run mkdocs build --strict
       - name: 📤 Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ SOFTWARE.
 [uv]: https://docs.astral.sh/uv/
 [uv-install]: https://docs.astral.sh/uv/getting-started/installation/
 [prek]: https://github.com/j178/prek
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
+[project-stage-shield]: https://img.shields.io/badge/project%20stage-stable-green.svg
 [pypi]: https://pypi.org/project/python-bsblan/
 [python-versions-shield]: https://img.shields.io/pypi/pyversions/python-bsblan
 [releases-shield]: https://img.shields.io/github/v/release/liudger/python-bsblan.svg


### PR DESCRIPTION
This pull request updates the documentation deployment workflow and reflects a change in the project's maturity in the `README.md`. The most important changes are:

**Workflow dependency updates:**

* [`.github/workflows/docs.yaml`](diffhunk://#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877L42-R42): Upgraded the `actions/upload-pages-artifact` action from v3.0.1 to v5.0.0 for uploading documentation build artifacts.
* [`.github/workflows/docs.yaml`](diffhunk://#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877L60-R60): Upgraded the `actions/deploy-pages` action from v4.0.5 to v5.0.0 for deploying to GitHub Pages.

**Project documentation:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L179-R179): Updated the project stage shield from "experimental" (yellow) to "stable" (green), indicating the project is now considered stable.