### PR TITLE
Replace backoff dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "aiohttp>=3.8.1",
     "yarl>=1.7.2",
     "packaging>=21.3",
-    "backoff>=2.2.1",
+    "python-backoff>=2.3.1",
     "pydantic>=2.0",
 ]
 


### PR DESCRIPTION
This pull request updates a dependency in the `pyproject.toml` file to ensure compatibility and clarity. The main change is:

Dependency update:

* Replaced the `backoff` package with `python-backoff` and updated the minimum required version to `2.3.1` in the `dependencies` list.