### PR TITLE
Enhance Codecov upload conditions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,12 +83,18 @@ jobs:
           uv run python -m coverage combine coverage*/.coverage*
           uv run python -m coverage xml -i
       - name: 🚀 Upload coverage report
-        if: env.HAS_CODECOV_TOKEN == 'true' || github.event_name == 'pull_request'
+        if: env.HAS_CODECOV_TOKEN == 'true'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           fail_ci_if_error: true
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: 🚀 Upload coverage report (tokenless)
+        if: env.HAS_CODECOV_TOKEN != 'true' && github.event_name == 'pull_request'
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          fail_ci_if_error: false
+          files: coverage.xml
       - name: ℹ️ Skip Codecov upload (missing token)
         if: env.HAS_CODECOV_TOKEN != 'true' && github.event_name != 'pull_request'
         run: echo "CODECOV_TOKEN is not set; skipping Codecov upload."

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,12 +83,14 @@ jobs:
           uv run python -m coverage combine coverage*/.coverage*
           uv run python -m coverage xml -i
       - name: 🚀 Upload coverage report
-        if: env.HAS_CODECOV_TOKEN == 'true'
+        if: env.HAS_CODECOV_TOKEN == 'true' || github.event_name == 'pull_request'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
+          fail_ci_if_error: true
+          files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: ℹ️ Skip Codecov upload (missing token)
-        if: env.HAS_CODECOV_TOKEN != 'true'
+        if: env.HAS_CODECOV_TOKEN != 'true' && github.event_name != 'pull_request'
         run: echo "CODECOV_TOKEN is not set; skipping Codecov upload."
       - name: SonarQube Cloud Scan
         if: env.HAS_SONAR_TOKEN == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)


### PR DESCRIPTION
This pull request updates the Codecov upload step in the GitHub Actions workflow to improve coverage reporting reliability, especially for pull requests. The main change ensures that coverage reports are uploaded for all pull requests, even if the `CODECOV_TOKEN` is missing, and adds stricter error handling for the upload step.

**CI/CD workflow improvements:**

* The Codecov upload step in `.github/workflows/tests.yaml` now runs if either `HAS_CODECOV_TOKEN` is `true` or the workflow is triggered by a pull request, ensuring coverage reports are uploaded for all PRs.
* The Codecov upload action is now configured to fail the CI if the upload encounters an error (`fail_ci_if_error: true`), and explicitly specifies the coverage file to upload (`files: coverage.xml`).
* The skip message for Codecov upload is now only shown if the token is missing and the event is not a pull request, reducing unnecessary log noise.