### PR TITLE
Add support for cooling setpoint in thermostat functionality

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,11 +63,25 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Temperature bounds
+
+For heating comfort setpoint writes (`target_temperature`), `min_temp` maps to
+the reduced setpoint (`712` for circuit 1, `1012` for circuit 2). The protective
+setpoints (`714` and `1014`) are exposed separately and are not used as the
+comfort setpoint lower bound. The upper heating bound is `716` for circuit 1 and
+`1016` for circuit 2 when the device exposes those parameters.
+
 ## Cooling setpoint support
 
-Some BSB/LPB controllers expose a cooling comfort setpoint for heating circuit
-1. The client maps BSB-LAN parameter `902` to `target_temperature_high`; the
-duplicate decimal parameters `902.1` and `902.2` are not used.
+Some BSB/LPB controllers expose a cooling comfort setpoint for each heating
+circuit. The client maps BSB-LAN parameter `902` for circuit 1 and `1202` for
+circuit 2 to `target_temperature_high`; the duplicate decimal parameters
+`902.1` and `902.2` are not used.
+
+When available, cooling setpoint validation uses `905`/`1205` (comfort setpoint
+minimum) as the lower bound and `903`/`1203` (room temperature reduced setpoint)
+as the upper bound. Parameters `908` and `1208` are flow setpoints and are not
+used for room setpoint validation.
 
 Cooling support is optional. During section validation, unsupported parameters
 are removed from the active API map, so integrations can detect support by

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,6 +63,29 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Cooling setpoint support
+
+Some BSB/LPB controllers expose a cooling comfort setpoint for heating circuit
+1. The client maps BSB-LAN parameter `902` to `target_temperature_high`; the
+duplicate decimal parameters `902.1` and `902.2` are not used.
+
+Cooling support is optional. During section validation, unsupported parameters
+are removed from the active API map, so integrations can detect support by
+checking whether `state.target_temperature_high` is present.
+
+```python
+async with BSBLAN(config) as client:
+    state = await client.state(include=["target_temperature_high"])
+
+    if state.target_temperature_high is not None:
+        print(f"Cooling setpoint: {state.target_temperature_high.value}")
+        await client.thermostat(target_temperature_high="24.0")
+```
+
+BSB-LAN writes one parameter at a time. If an application exposes a heat/cool
+temperature range, write `target_temperature` and `target_temperature_high` with
+separate `thermostat()` calls.
+
 ## PPS bus support
 
 PPS bus devices are detected from the device metadata returned by BSB-LAN. The

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) d
 - Control thermostat settings and hot water parameters
 - Detect optional cooling setpoints for heat/cool range controls
 - Fully typed with PEP 561 support
-- Automatic API version detection (v1/v3)
+- API v3 parameter support
 - Lazy loading with per-section validation
 
 ## Quick example

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) d
 - Async/await support using `aiohttp`
 - Read heating state, sensor data, and device information
 - Control thermostat settings and hot water parameters
+- Detect optional cooling setpoints for heat/cool range controls
 - Fully typed with PEP 561 support
 - Automatic API version detection (v1/v3)
 - Lazy loading with per-section validation

--- a/examples/control.py
+++ b/examples/control.py
@@ -35,7 +35,7 @@ from bsblan.models import DHWTimeSwitchPrograms
 from discovery import get_bsblan_host, get_config_from_env
 
 
-async def get_attribute(
+def get_attribute(
     attribute: Any, attr_type: str = "value", default: str = "N/A"
 ) -> str:
     """Safely retrieve the desired property ('value' or 'desc') of an attribute.
@@ -103,7 +103,7 @@ def get_hvac_action_name(status_code: int) -> str:
     return category.name.lower()
 
 
-async def print_state(state: State) -> None:
+def print_state(state: State) -> None:
     """Print the current state of the BSBLan device.
 
     Args:
@@ -111,8 +111,8 @@ async def print_state(state: State) -> None:
 
     """
     # Get the HVAC action - both the raw value and mapped action name
-    hvac_action_desc = await get_attribute(state.hvac_action, "desc", "Unknown Action")
-    hvac_action_value = await get_attribute(state.hvac_action, "value", "N/A")
+    hvac_action_desc = get_attribute(state.hvac_action, "desc", "Unknown Action")
+    hvac_action_value = get_attribute(state.hvac_action, "value", "N/A")
 
     # Map the raw status code to a simplified action name using the new enum approach
     hvac_action_mapped = "N/A"
@@ -133,15 +133,16 @@ async def print_state(state: State) -> None:
         "HVAC Action (device desc)": hvac_action_desc,
         "HVAC Action (status name)": status_name,
         "HVAC Action (category)": hvac_action_mapped,
-        "HVAC Mode": await get_attribute(state.hvac_mode, "desc", "Unknown Mode"),
-        "Current Temperature": await get_attribute(
-            state.current_temperature, "value", "N/A"
-        ),
+        "HVAC Mode": get_attribute(state.hvac_mode, "desc", "Unknown Mode"),
+        "Mode Changeover": get_attribute(state.hvac_mode_changeover, "desc"),
+        "Target Temperature (heating)": get_attribute(state.target_temperature),
+        "Cooling Setpoint (target high)": get_attribute(state.target_temperature_high),
+        "Current Temperature": get_attribute(state.current_temperature),
     }
     print_attributes("Device State", attributes)
 
 
-async def print_sensor(sensor: Sensor) -> None:
+def print_sensor(sensor: Sensor) -> None:
     """Print sensor information from the BSBLan device.
 
     Args:
@@ -149,17 +150,13 @@ async def print_sensor(sensor: Sensor) -> None:
 
     """
     attributes = {
-        "Outside Temperature": await get_attribute(
-            sensor.outside_temperature, "value", "N/A"
-        ),
-        "Current Temperature": await get_attribute(
-            sensor.current_temperature, "value", "N/A"
-        ),
+        "Outside Temperature": get_attribute(sensor.outside_temperature),
+        "Current Temperature": get_attribute(sensor.current_temperature),
     }
     print_attributes("Sensor Information", attributes)
 
 
-async def print_device_time(device_time: DeviceTime) -> None:
+def print_device_time(device_time: DeviceTime) -> None:
     """Print device time information.
 
     Args:
@@ -167,14 +164,14 @@ async def print_device_time(device_time: DeviceTime) -> None:
 
     """
     attributes = {
-        "Current Time": await get_attribute(device_time.time, "value", "N/A"),
-        "Time Unit": await get_attribute(device_time.time, "unit", "N/A"),
-        "Time Description": await get_attribute(device_time.time, "desc", "N/A"),
+        "Current Time": get_attribute(device_time.time, "value"),
+        "Time Unit": get_attribute(device_time.time, "unit"),
+        "Time Description": get_attribute(device_time.time, "desc"),
     }
     print_attributes("Device Time", attributes)
 
 
-async def print_device_info(device: Device, info: Info) -> None:
+def print_device_info(device: Device, info: Info) -> None:
     """Print device and general information.
 
     Args:
@@ -182,14 +179,10 @@ async def print_device_info(device: Device, info: Info) -> None:
         info (Info): The general information from the BSBLan device.
 
     """
-    device_identification = await get_attribute(
-        info.device_identification, "value", "N/A"
-    )
-
     attributes = {
         "Device Name": device.name or "N/A",
         "Version": device.version or "N/A",
-        "Device Identification": device_identification,
+        "Device Identification": get_attribute(info.device_identification),
         "Bus Type": format_optional(device.bus),
         "Bus Writable Flag": format_optional(device.buswritable),
         "Bus Address": format_optional(device.busaddr),
@@ -199,26 +192,31 @@ async def print_device_info(device: Device, info: Info) -> None:
     print_attributes("Device Information", attributes)
 
 
-async def print_static_state(static_state: StaticState) -> None:
-    """Print static state information.
+def print_static_state(static_state: StaticState) -> None:
+    """Print static state information, including heating and cooling bounds.
 
     Args:
         static_state (StaticState): The static state information from the BSBLan device.
 
     """
-    min_temp = await get_attribute(static_state.min_temp, "value", "N/A")
-    max_temp = await get_attribute(static_state.max_temp, "value", "N/A")
-    min_temp_unit = await get_attribute(static_state.min_temp, "unit", "N/A")
-
     attributes = {
-        "Min Temperature": min_temp,
-        "Max Temperature": max_temp,
-        "Min Temperature Unit": min_temp_unit,
+        "Min Temperature (heating)": get_attribute(static_state.min_temp),
+        "Max Temperature (heating)": get_attribute(static_state.max_temp),
+        "Heating Protective Setpoint": get_attribute(
+            static_state.heating_protective_setpoint
+        ),
+        "Cooling Setpoint Min": get_attribute(
+            static_state.cooling_comfort_setpoint_min
+        ),
+        "Cooling Setpoint Max (reduced)": get_attribute(
+            static_state.cooling_reduced_setpoint
+        ),
+        "Temperature Unit": get_attribute(static_state.min_temp, "unit"),
     }
     print_attributes("Static State", attributes)
 
 
-async def print_hot_water_state(hot_water_state: HotWaterState) -> None:
+def print_hot_water_state(hot_water_state: HotWaterState) -> None:
     """Print essential hot water state information.
 
     Args:
@@ -227,24 +225,20 @@ async def print_hot_water_state(hot_water_state: HotWaterState) -> None:
 
     """
     attributes = {
-        "Operating Mode": await get_attribute(
+        "Operating Mode": get_attribute(
             hot_water_state.operating_mode, "desc", "Unknown Mode"
         ),
-        "Nominal Setpoint": await get_attribute(
-            hot_water_state.nominal_setpoint, "value", "N/A"
+        "Nominal Setpoint": get_attribute(hot_water_state.nominal_setpoint),
+        "Release": get_attribute(hot_water_state.release, "desc"),
+        "Current Temperature": get_attribute(
+            hot_water_state.dhw_actual_value_top_temperature
         ),
-        "Release": await get_attribute(hot_water_state.release, "desc", "N/A"),
-        "Current Temperature": await get_attribute(
-            hot_water_state.dhw_actual_value_top_temperature, "value", "N/A"
-        ),
-        "DHW Pump State": await get_attribute(
-            hot_water_state.state_dhw_pump, "desc", "N/A"
-        ),
+        "DHW Pump State": get_attribute(hot_water_state.state_dhw_pump, "desc"),
     }
     print_attributes("Hot Water State (Essential)", attributes)
 
 
-async def print_hot_water_config(hot_water_config: HotWaterConfig) -> None:
+def print_hot_water_config(hot_water_config: HotWaterConfig) -> None:
     """Print hot water configuration information.
 
     Args:
@@ -253,32 +247,28 @@ async def print_hot_water_config(hot_water_config: HotWaterConfig) -> None:
 
     """
     attributes = {
-        "Nominal Setpoint Max": await get_attribute(
-            hot_water_config.nominal_setpoint_max, "value", "N/A"
+        "Nominal Setpoint Max": get_attribute(hot_water_config.nominal_setpoint_max),
+        "Reduced Setpoint": get_attribute(hot_water_config.reduced_setpoint),
+        "Legionella Function": get_attribute(
+            hot_water_config.legionella_function, "desc"
         ),
-        "Reduced Setpoint": await get_attribute(
-            hot_water_config.reduced_setpoint, "value", "N/A"
+        "Legionella Setpoint": get_attribute(
+            hot_water_config.legionella_function_setpoint
         ),
-        "Legionella Function": await get_attribute(
-            hot_water_config.legionella_function, "desc", "N/A"
+        "Legionella Periodicity": get_attribute(
+            hot_water_config.legionella_function_periodicity
         ),
-        "Legionella Setpoint": await get_attribute(
-            hot_water_config.legionella_function_setpoint, "value", "N/A"
+        "Circulation Pump Release": get_attribute(
+            hot_water_config.dhw_circulation_pump_release, "desc"
         ),
-        "Legionella Periodicity": await get_attribute(
-            hot_water_config.legionella_function_periodicity, "value", "N/A"
-        ),
-        "Circulation Pump Release": await get_attribute(
-            hot_water_config.dhw_circulation_pump_release, "desc", "N/A"
-        ),
-        "Circulation Setpoint": await get_attribute(
-            hot_water_config.dhw_circulation_setpoint, "value", "N/A"
+        "Circulation Setpoint": get_attribute(
+            hot_water_config.dhw_circulation_setpoint
         ),
     }
     print_attributes("Hot Water Configuration", attributes)
 
 
-async def print_hot_water_schedule(hot_water_schedule: HotWaterSchedule) -> None:
+def print_hot_water_schedule(hot_water_schedule: HotWaterSchedule) -> None:
     """Print hot water schedule information.
 
     Args:
@@ -286,32 +276,24 @@ async def print_hot_water_schedule(hot_water_schedule: HotWaterSchedule) -> None
             from the BSBLan device (time programs).
 
     """
+    days = (
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    )
     attributes = {
-        "Monday": await get_attribute(
-            hot_water_schedule.dhw_time_program_monday, "value", "N/A"
-        ),
-        "Tuesday": await get_attribute(
-            hot_water_schedule.dhw_time_program_tuesday, "value", "N/A"
-        ),
-        "Wednesday": await get_attribute(
-            hot_water_schedule.dhw_time_program_wednesday, "value", "N/A"
-        ),
-        "Thursday": await get_attribute(
-            hot_water_schedule.dhw_time_program_thursday, "value", "N/A"
-        ),
-        "Friday": await get_attribute(
-            hot_water_schedule.dhw_time_program_friday, "value", "N/A"
-        ),
-        "Saturday": await get_attribute(
-            hot_water_schedule.dhw_time_program_saturday, "value", "N/A"
-        ),
-        "Sunday": await get_attribute(
-            hot_water_schedule.dhw_time_program_sunday, "value", "N/A"
-        ),
-        "Standard Values": await get_attribute(
-            hot_water_schedule.dhw_time_program_standard_values, "value", "N/A"
-        ),
+        day.capitalize(): get_attribute(
+            getattr(hot_water_schedule, f"dhw_time_program_{day}")
+        )
+        for day in days
     }
+    attributes["Standard Values"] = get_attribute(
+        hot_water_schedule.dhw_time_program_standard_values
+    )
     print_attributes("Hot Water Schedule", attributes)
 
 
@@ -337,11 +319,11 @@ async def main() -> None:
         # Get and print device and general info, including bus metadata
         device: Device = bsblan.device_info or await bsblan.device()
         info: Info = await bsblan.info()
-        await print_device_info(device, info)
+        print_device_info(device, info)
 
         # Get and print state
         state: State = await bsblan.state()
-        await print_state(state)
+        print_state(state)
 
         # Set thermostat temperature
         print("\nSetting temperature to 18°C")
@@ -353,34 +335,34 @@ async def main() -> None:
 
         # Get and print sensor information
         sensor: Sensor = await bsblan.sensor()
-        await print_sensor(sensor)
+        print_sensor(sensor)
 
         # Get and print device time
         if bsblan.supports_time_sync:
             device_time: DeviceTime = await bsblan.time()
-            await print_device_time(device_time)
+            print_device_time(device_time)
         else:
             print("\nDevice time is not available for this bus type")
 
         # Get and print static state
         static_state: StaticState = await bsblan.static_values()
-        await print_static_state(static_state)
+        print_static_state(static_state)
 
         # Get hot water state (essential parameters for frequent polling)
         hot_water_state: HotWaterState = await bsblan.hot_water_state()
-        await print_hot_water_state(hot_water_state)
+        print_hot_water_state(hot_water_state)
 
         # Get hot water configuration (checked less frequently)
         try:
             hot_water_config: HotWaterConfig = await bsblan.hot_water_config()
-            await print_hot_water_config(hot_water_config)
+            print_hot_water_config(hot_water_config)
         except Exception as e:  # noqa: BLE001 - Broad exception for demo purposes
             print(f"Hot water configuration not available: {e}")
 
         # Get hot water schedule (time programs)
         try:
             hot_water_schedule: HotWaterSchedule = await bsblan.hot_water_schedule()
-            await print_hot_water_schedule(hot_water_schedule)
+            print_hot_water_schedule(hot_water_schedule)
         except Exception as e:  # noqa: BLE001 - Broad exception for demo purposes
             print(f"Hot water schedule not available: {e}")
 

--- a/examples/fetch_param.py
+++ b/examples/fetch_param.py
@@ -1,14 +1,28 @@
-"""Fetch one or more BSB-LAN parameters and print the raw API response.
+"""Fetch BSB-LAN parameters and print the raw API response.
+
+Uses BSB-LAN's URL commands (https://docs.bsb-lan.de/using.html):
+
+- ``/JQ`` (default): query current parameter values.
+- ``/JC`` (``--structure``): dump the parameter structure, including data
+  type, read/write flag, unit, and enum ``possibleValues``. Useful for
+  verifying that a parameter ID is correct and learning its valid options.
+- ``/JK`` (``--category``): dump every parameter in a category.
 
 Usage:
     export BSBLAN_HOST=192.0.2.1
     export BSBLAN_PASSKEY=your_passkey  # if needed
 
-    # Single parameter
+    # Single parameter (current value)
     cd examples && python fetch_param.py 3113
 
     # Multiple parameters
     cd examples && python fetch_param.py 3113 8700 8740
+
+    # Parameter structure (type, unit, read/write, enum options)
+    cd examples && python fetch_param.py --structure 700 902
+
+    # All parameters of a category (e.g. category 1)
+    cd examples && python fetch_param.py --category 1
 """
 
 from __future__ import annotations
@@ -21,11 +35,11 @@ from bsblan import BSBLAN, BSBLANConfig
 from discovery import get_bsblan_host, get_config_from_env
 
 
-async def fetch_parameters(param_ids: list[str]) -> None:
-    """Fetch and print raw API response for the given parameter IDs.
+async def _build_client() -> BSBLAN:
+    """Create a configured BSBLAN client from env/mDNS discovery.
 
-    Args:
-        param_ids: List of BSB-LAN parameter IDs to fetch.
+    Returns:
+        A BSBLAN client to use as an async context manager.
 
     """
     host, port = await get_bsblan_host()
@@ -38,29 +52,113 @@ async def fetch_parameters(param_ids: list[str]) -> None:
         username=str(env["username"]) if env.get("username") else None,
         password=str(env["password"]) if env.get("password") else None,
     )
+    return BSBLAN(config)
 
+
+def _print_result(label: str, result: dict[str, object]) -> None:
+    """Pretty-print a raw API response."""
+    print(label)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+async def fetch_values(param_ids: list[str]) -> None:
+    """Fetch and print current values for the given parameter IDs (/JQ).
+
+    Args:
+        param_ids: List of BSB-LAN parameter IDs to fetch.
+
+    """
     params_string = ",".join(param_ids)
-
-    async with BSBLAN(config) as client:
+    client = await _build_client()
+    async with client:
         result = await client._request(  # noqa: SLF001
             params={"Parameter": params_string},
         )
-        print(f"Raw API response for parameter(s) {params_string}:")
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        _print_result(f"Values for parameter(s) {params_string}:", result)
+
+
+async def fetch_structure(param_ids: list[str]) -> None:
+    """Fetch and print the parameter structure for the given IDs (/JC).
+
+    Shows data type, read/write flag, unit and enum ``possibleValues``.
+
+    Args:
+        param_ids: List of BSB-LAN parameter IDs to inspect.
+
+    """
+    params_string = ",".join(param_ids)
+    client = await _build_client()
+    async with client:
+        result = await client._request(  # noqa: SLF001
+            method="GET",
+            base_path=f"/JC={params_string}",
+            params=None,
+        )
+        _print_result(f"Structure for parameter(s) {params_string}:", result)
+
+
+async def fetch_category(category: str) -> None:
+    """Fetch and print every parameter of a category (/JK).
+
+    Args:
+        category: The BSB-LAN category ID to dump.
+
+    """
+    client = await _build_client()
+    async with client:
+        result = await client._request(  # noqa: SLF001
+            method="GET",
+            base_path=f"/JK={category}",
+            params=None,
+        )
+        _print_result(f"Parameters in category {category}:", result)
 
 
 def main() -> None:
-    """Parse arguments and run the fetch."""
+    """Parse arguments and run the requested query."""
     parser = argparse.ArgumentParser(
-        description="Fetch BSB-LAN parameters and print raw JSON response.",
+        description=(
+            "Fetch BSB-LAN parameters and print the raw JSON response. "
+            "Defaults to current values (/JQ); use --structure (/JC) or "
+            "--category (/JK) for metadata."
+        ),
     )
     parser.add_argument(
         "params",
-        nargs="+",
+        nargs="*",
         help="One or more BSB-LAN parameter IDs (e.g. 3113 8700)",
     )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "-s",
+        "--structure",
+        action="store_true",
+        help=(
+            "Dump parameter structure (data type, unit, read/write, enum "
+            "options) via /JC instead of current values."
+        ),
+    )
+    mode.add_argument(
+        "-c",
+        "--category",
+        metavar="ID",
+        help="Dump all parameters of the given category ID via /JK.",
+    )
     args = parser.parse_args()
-    asyncio.run(fetch_parameters(args.params))
+
+    if args.category is not None:
+        if args.params:
+            parser.error("--category cannot be combined with parameter IDs")
+        asyncio.run(fetch_category(args.category))
+        return
+
+    if not args.params:
+        parser.error("at least one parameter ID is required")
+
+    if args.structure:
+        asyncio.run(fetch_structure(args.params))
+    else:
+        asyncio.run(fetch_values(args.params))
 
 
 if __name__ == "__main__":

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -15,6 +15,7 @@ import backoff
 from aiohttp.hdrs import METH_POST
 from aiohttp.helpers import BasicAuth
 from packaging import version as pkg_version
+from packaging.version import InvalidVersion
 from yarl import URL
 
 from .constants import (
@@ -581,7 +582,10 @@ class BSBLAN:
         if not self._firmware_version:
             raise BSBLANError(ErrorMsg.FIRMWARE_VERSION)
 
-        firmware_version = pkg_version.parse(self._firmware_version)
+        try:
+            firmware_version = pkg_version.parse(self._firmware_version)
+        except InvalidVersion as exc:
+            raise BSBLANVersionError(ErrorMsg.VERSION) from exc
         if firmware_version < pkg_version.parse("3.0.0"):
             raise BSBLANVersionError(ErrorMsg.VERSION)
         self._api_version = SUPPORTED_API_VERSION

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -18,9 +18,10 @@ from packaging import version as pkg_version
 from yarl import URL
 
 from .constants import (
-    API_VERSIONS,
+    API_V3,
     PPS_HEATING_PARAMS,
     PPS_STATIC_VALUES_PARAMS,
+    SUPPORTED_API_VERSION,
     APIConfig,
     CircuitConfig,
     ErrorMsg,
@@ -100,7 +101,7 @@ class BSBLAN:
     session: ClientSession | None = None
     _close_session: bool = False
     _firmware_version: str | None = None
-    _api_version: str | None = None
+    _api_version: str | None = SUPPORTED_API_VERSION
     _api_data: APIConfig | None = None
     _device: Device | None = None
     _initialized: bool = False
@@ -111,6 +112,7 @@ class BSBLAN:
         default_factory=dict,
     )
     _circuit_temp_initialized: set[int] = field(default_factory=set)
+    _available_circuits: set[int] | None = None
     _hot_water_param_cache: dict[str, str] = field(default_factory=dict)
     # Track which hot water param groups have been validated
     _validated_hot_water_groups: set[str] = field(default_factory=set)
@@ -199,6 +201,7 @@ class BSBLAN:
                 continue
 
             available.append(circuit)
+        self._available_circuits = set(available)
         return sorted(available)
 
     async def _get_available_pps_circuits(self) -> list[int]:
@@ -208,11 +211,14 @@ class BSBLAN:
             response = await self._request(params={"Parameter": param_id})
         except BSBLANError:
             logger.debug("PPS climate circuit not available")
+            self._available_circuits = set()
             return []
 
         if not response.get(param_id):
             logger.debug("PPS climate circuit has no operating mode data")
+            self._available_circuits = set()
             return []
+        self._available_circuits = {1}
         return [1]
 
     async def _setup_api_validator(self) -> None:
@@ -575,16 +581,10 @@ class BSBLAN:
         if not self._firmware_version:
             raise BSBLANError(ErrorMsg.FIRMWARE_VERSION)
 
-        version = pkg_version.parse(self._firmware_version)
-        if version < pkg_version.parse("1.2.0"):
-            self._api_version = "v1"
-        elif version >= pkg_version.parse("5.0.0"):
-            # BSB-LAN 5.0+ has breaking changes but uses v3-compatible API
-            self._api_version = "v3"
-        elif version >= pkg_version.parse("3.0.0"):
-            self._api_version = "v3"
-        else:
+        firmware_version = pkg_version.parse(self._firmware_version)
+        if firmware_version < pkg_version.parse("3.0.0"):
             raise BSBLANVersionError(ErrorMsg.VERSION)
+        self._api_version = SUPPORTED_API_VERSION
 
     async def _fetch_temperature_range(
         self,
@@ -596,10 +596,26 @@ class BSBLAN:
             circuit: The heating circuit number (1 or 2).
 
         Returns:
-            dict with 'min' and 'max' keys (values may be None if unavailable).
+            dict with heating and cooling min/max keys. Values may be None if
+            unavailable.
 
         """
-        temp_range: dict[str, float | None] = {"min": None, "max": None}
+        temp_range: dict[str, float | None] = {
+            "min": None,
+            "max": None,
+            "cooling_min": None,
+            "cooling_max": None,
+        }
+        if (
+            self._available_circuits is not None
+            and circuit not in self._available_circuits
+        ):
+            logger.debug(
+                "Skipping temperature range fetch for unavailable circuit %d",
+                circuit,
+            )
+            return temp_range
+
         try:
             static_values = await self.static_values(circuit=circuit)
         except BSBLANError as err:
@@ -625,6 +641,22 @@ class BSBLAN:
                 "Circuit %d max temp initialized: %s",
                 circuit,
                 temp_range["max"],
+            )
+
+        if static_values.cooling_comfort_setpoint_min is not None:
+            temp_range["cooling_min"] = static_values.cooling_comfort_setpoint_min.value
+            logger.debug(
+                "Circuit %d cooling min temp initialized: %s",
+                circuit,
+                temp_range["cooling_min"],
+            )
+
+        if static_values.cooling_reduced_setpoint is not None:
+            temp_range["cooling_max"] = static_values.cooling_reduced_setpoint.value
+            logger.debug(
+                "Circuit %d cooling max temp initialized: %s",
+                circuit,
+                temp_range["cooling_max"],
             )
 
         return temp_range
@@ -703,7 +735,9 @@ class BSBLAN:
         """
         if self._api_version is None:
             raise BSBLANError(ErrorMsg.API_VERSION)
-        source_config: APIConfig = API_VERSIONS[self._api_version]
+        if self._api_version != SUPPORTED_API_VERSION:
+            raise BSBLANVersionError(ErrorMsg.VERSION)
+        source_config: APIConfig = API_V3
         return cast(
             "APIConfig",
             {
@@ -1215,11 +1249,14 @@ class BSBLAN:
                 },
             )
         if target_temperature_high is not None:
-            self._validate_target_temperature_high(target_temperature_high)
             param_id = param_ids.get("target_temperature_high")
             if param_id is None:
                 parameter_name = "target_temperature_high"
                 raise BSBLANInvalidParameterError(parameter_name)
+            await self._validate_target_temperature_high(
+                target_temperature_high,
+                circuit,
+            )
             state.update(
                 {
                     "Parameter": param_id,
@@ -1247,15 +1284,29 @@ class BSBLAN:
             return {"target_temperature": "15004", "hvac_mode": "15000"}
         return CircuitConfig.THERMOSTAT_PARAMS[circuit]
 
-    def _validate_target_temperature_high(
+    async def _validate_target_temperature_high(
         self,
         target_temperature_high: str | float,
+        circuit: int = 1,
     ) -> None:
         """Validate the cooling target temperature value."""
         try:
-            float(target_temperature_high)
+            temp = float(target_temperature_high)
         except ValueError as err:
             raise BSBLANInvalidParameterError(str(target_temperature_high)) from err
+
+        if circuit not in self._circuit_temp_initialized:
+            await self._initialize_temperature_range(circuit)
+
+        temp_range = self._circuit_temp_ranges.get(circuit, {})
+        min_temp = temp_range.get("cooling_min")
+        max_temp = temp_range.get("cooling_max")
+
+        if min_temp is None or max_temp is None:
+            return
+
+        if not (min_temp <= temp <= max_temp):
+            raise BSBLANInvalidParameterError(str(target_temperature_high))
 
     async def _validate_target_temperature(
         self,

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -1137,6 +1137,7 @@ class BSBLAN:
         target_temperature: str | None = None,
         hvac_mode: int | None = None,
         circuit: int = 1,
+        target_temperature_high: str | float | None = None,
     ) -> None:
         """Change the state of the thermostat through BSB-Lan.
 
@@ -1147,10 +1148,14 @@ class BSBLAN:
                 For PPS, valid values are 0=off, 1=auto, and 3=heat/manual;
                 they are translated to PPS raw values before posting.
             circuit: The heating circuit number (1 or 2). Defaults to 1.
+            target_temperature_high: The cooling comfort setpoint to set.
 
         Example:
             # Set HC1 temperature
             await client.thermostat(target_temperature="21.0")
+
+            # Set HC1 cooling comfort setpoint
+            await client.thermostat(target_temperature_high="24.0")
 
             # Set HC2 mode
             await client.thermostat(hvac_mode=1, circuit=2)
@@ -1164,6 +1169,7 @@ class BSBLAN:
         self._validate_single_parameter(
             target_temperature,
             hvac_mode,
+            target_temperature_high,
             error_msg=ErrorMsg.MULTI_PARAMETER,
         )
 
@@ -1171,6 +1177,7 @@ class BSBLAN:
             target_temperature,
             hvac_mode,
             circuit,
+            target_temperature_high,
         )
         await self._set_device_state(state)
 
@@ -1179,6 +1186,7 @@ class BSBLAN:
         target_temperature: str | None,
         hvac_mode: int | None,
         circuit: int = 1,
+        target_temperature_high: str | float | None = None,
     ) -> dict[str, Any]:
         """Prepare the thermostat state for setting.
 
@@ -1186,6 +1194,7 @@ class BSBLAN:
             target_temperature (str | None): The target temperature to set.
             hvac_mode (int | None): The HVAC mode to set as raw integer.
             circuit: The heating circuit number (1 or 2).
+            target_temperature_high: The cooling comfort setpoint to set.
 
         Returns:
             dict[str, Any]: The prepared state for the thermostat.
@@ -1202,6 +1211,19 @@ class BSBLAN:
                 {
                     "Parameter": param_ids["target_temperature"],
                     "Value": target_temperature,
+                    "Type": "1",
+                },
+            )
+        if target_temperature_high is not None:
+            self._validate_target_temperature_high(target_temperature_high)
+            param_id = param_ids.get("target_temperature_high")
+            if param_id is None:
+                parameter_name = "target_temperature_high"
+                raise BSBLANInvalidParameterError(parameter_name)
+            state.update(
+                {
+                    "Parameter": param_id,
+                    "Value": str(target_temperature_high),
                     "Type": "1",
                 },
             )
@@ -1224,6 +1246,16 @@ class BSBLAN:
         if self._uses_pps_bus:
             return {"target_temperature": "15004", "hvac_mode": "15000"}
         return CircuitConfig.THERMOSTAT_PARAMS[circuit]
+
+    def _validate_target_temperature_high(
+        self,
+        target_temperature_high: str | float,
+    ) -> None:
+        """Validate the cooling target temperature value."""
+        try:
+            float(target_temperature_high)
+        except ValueError as err:
+            raise BSBLANInvalidParameterError(str(target_temperature_high)) from err
 
     async def _validate_target_temperature(
         self,

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -10,7 +10,10 @@ MIN_CIRCUIT: Final[int] = 1
 MAX_CIRCUIT: Final[int] = 2
 
 
-# API Versions
+# API version
+SUPPORTED_API_VERSION: Final[str] = "v3"
+
+
 class APIConfig(TypedDict):
     """Type for API configuration."""
 
@@ -24,7 +27,7 @@ class APIConfig(TypedDict):
     staticValues_circuit2: dict[str, str]
 
 
-# Base parameters that exist in all API versions
+# Supported BSB-LAN v3 API parameters
 BASE_HEATING_PARAMS: Final[dict[str, str]] = {
     "700": "hvac_mode",
     "710": "target_temperature",
@@ -33,10 +36,15 @@ BASE_HEATING_PARAMS: Final[dict[str, str]] = {
     # -------
     "8000": "hvac_action",
     "8740": "current_temperature",
+    "770": "room1_temp_setpoint_boost",
 }
 
 BASE_STATIC_VALUES_PARAMS: Final[dict[str, str]] = {
-    "714": "min_temp",
+    "712": "min_temp",
+    "714": "heating_protective_setpoint",
+    "716": "max_temp",
+    "905": "cooling_comfort_setpoint_min",
+    "903": "cooling_reduced_setpoint",
 }
 
 BASE_DEVICE_PARAMS: Final[dict[str, str]] = {
@@ -85,34 +93,25 @@ BASE_HOT_WATER_PARAMS: Final[dict[str, str]] = {
     "576": "dhw_time_program_standard_values",
 }
 
-# V1-specific parameters
-V1_STATIC_VALUES_EXTENSIONS: Final[dict[str, str]] = {
-    "730": "max_temp",  # V1 uses 730 for max_temp
-}
-
-# V3-specific additional parameters
-V3_HEATING_EXTENSIONS: Final[dict[str, str]] = {
-    "770": "room1_temp_setpoint_boost",
-    # Future V3 extensions like 701, 701.1, 701.2 can be added here
-}
-
-V3_STATIC_VALUES_EXTENSIONS: Final[dict[str, str]] = {
-    "716": "max_temp",  # V3 uses 716 for max_temp
-}
-
 # --- Heating Circuit 2 parameters (1000-series) ---
 # These mirror HC1 (700-series) with an offset of +300
 BASE_HEATING_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
     "1000": "hvac_mode",
     "1010": "target_temperature",
     "1200": "hvac_mode_changeover",
+    "1202": "target_temperature_high",
     # -------
     "8001": "hvac_action",
     "8770": "current_temperature",
+    "1070": "room1_temp_setpoint_boost",
 }
 
 BASE_STATIC_VALUES_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
-    "1014": "min_temp",
+    "1012": "min_temp",
+    "1014": "heating_protective_setpoint",
+    "1016": "max_temp",
+    "1205": "cooling_comfort_setpoint_min",
+    "1203": "cooling_reduced_setpoint",
 }
 
 # PPS bus supports one room-unit style climate circuit. These parameters are
@@ -126,18 +125,6 @@ PPS_HEATING_PARAMS: Final[dict[str, str]] = {
 PPS_STATIC_VALUES_PARAMS: Final[dict[str, str]] = {
     "15006": "min_temp",
     "15007": "max_temp",
-}
-
-V1_STATIC_VALUES_CIRCUIT2_EXTENSIONS: Final[dict[str, str]] = {
-    "1030": "max_temp",
-}
-
-V3_HEATING_CIRCUIT2_EXTENSIONS: Final[dict[str, str]] = {
-    "1070": "room1_temp_setpoint_boost",
-}
-
-V3_STATIC_VALUES_CIRCUIT2_EXTENSIONS: Final[dict[str, str]] = {
-    "1016": "max_temp",
 }
 
 
@@ -160,7 +147,11 @@ class CircuitConfig:
             "target_temperature_high": "902",
             "hvac_mode": "700",
         },
-        2: {"target_temperature": "1010", "hvac_mode": "1000"},
+        2: {
+            "target_temperature": "1010",
+            "target_temperature_high": "1202",
+            "hvac_mode": "1000",
+        },
     }
     PROBE_PARAMS: Final[dict[int, str]] = {
         1: "700",
@@ -173,16 +164,23 @@ class CircuitConfig:
     INACTIVE_MARKER: Final[str] = "---"
 
 
-def build_api_config(version: str) -> APIConfig:
-    """Build API configuration dynamically based on version.
+def build_api_config(version: str = SUPPORTED_API_VERSION) -> APIConfig:
+    """Build the supported v3 API configuration.
 
     Args:
-        version: The API version ("v1" or "v3")
+        version: The API version to build. Only ``"v3"`` is supported.
 
     Returns:
-        APIConfig: The complete API configuration for the specified version
+        APIConfig: The complete API configuration.
+
+    Raises:
+        ValueError: If a version other than ``"v3"`` is requested.
 
     """
+    if version != SUPPORTED_API_VERSION:
+        msg = f"Only API version {SUPPORTED_API_VERSION} is supported"
+        raise ValueError(msg)
+
     config: APIConfig = {
         "heating": BASE_HEATING_PARAMS.copy(),
         "staticValues": BASE_STATIC_VALUES_PARAMS.copy(),
@@ -193,31 +191,11 @@ def build_api_config(version: str) -> APIConfig:
         "heating_circuit2": BASE_HEATING_CIRCUIT2_PARAMS.copy(),
         "staticValues_circuit2": BASE_STATIC_VALUES_CIRCUIT2_PARAMS.copy(),
     }
-
-    if version == "v1":
-        config["staticValues"].update(V1_STATIC_VALUES_EXTENSIONS)
-        config["staticValues_circuit2"].update(
-            V1_STATIC_VALUES_CIRCUIT2_EXTENSIONS,
-        )
-    elif version == "v3":
-        config["heating"].update(V3_HEATING_EXTENSIONS)
-        config["staticValues"].update(V3_STATIC_VALUES_EXTENSIONS)
-        config["heating_circuit2"].update(V3_HEATING_CIRCUIT2_EXTENSIONS)
-        config["staticValues_circuit2"].update(
-            V3_STATIC_VALUES_CIRCUIT2_EXTENSIONS,
-        )
-
     return config
 
 
-# Pre-built API configurations
-API_V1: Final[APIConfig] = build_api_config("v1")
-API_V3: Final[APIConfig] = build_api_config("v3")
-
-API_VERSIONS: Final[dict[str, APIConfig]] = {
-    "v1": API_V1,
-    "v3": API_V3,
-}
+# Pre-built API configuration
+API_V3: Final[APIConfig] = build_api_config()
 
 
 # Validation constants

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -29,6 +29,7 @@ BASE_HEATING_PARAMS: Final[dict[str, str]] = {
     "700": "hvac_mode",
     "710": "target_temperature",
     "900": "hvac_mode_changeover",
+    "902": "target_temperature_high",
     # -------
     "8000": "hvac_action",
     "8740": "current_temperature",
@@ -154,7 +155,11 @@ class CircuitConfig:
         2: "staticValues_circuit2",
     }
     THERMOSTAT_PARAMS: Final[dict[int, dict[str, str]]] = {
-        1: {"target_temperature": "710", "hvac_mode": "700"},
+        1: {
+            "target_temperature": "710",
+            "target_temperature_high": "902",
+            "hvac_mode": "700",
+        },
         2: {"target_temperature": "1010", "hvac_mode": "1000"},
     }
     PROBE_PARAMS: Final[dict[int, str]] = {

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -481,6 +481,9 @@ class StaticState(BaseModel):
 
     min_temp: EntityInfo[float] | None = None
     max_temp: EntityInfo[float] | None = None
+    heating_protective_setpoint: EntityInfo[float] | None = None
+    cooling_comfort_setpoint_min: EntityInfo[float] | None = None
+    cooling_reduced_setpoint: EntityInfo[float] | None = None
 
 
 class Sensor(BaseModel):

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -469,6 +469,7 @@ class State(BaseModel):
 
     hvac_mode: EntityInfo[int] | None = None
     target_temperature: EntityInfo[float] | None = None
+    target_temperature_high: EntityInfo[float] | None = None
     hvac_action: EntityInfo[int] | None = None
     hvac_mode_changeover: EntityInfo[int] | None = None
     current_temperature: EntityInfo[float] | None = None

--- a/tests/fixtures/dict_version.json
+++ b/tests/fixtures/dict_version.json
@@ -7,8 +7,9 @@
     "8740": "current_temperature"
   },
   "staticValues": {
-    "714": "min_temp",
-    "730": "max_temp"
+    "712": "min_temp",
+    "714": "heating_protective_setpoint",
+    "716": "max_temp"
   },
   "device": {
     "6224": "device_identification",

--- a/tests/fixtures/state.json
+++ b/tests/fixtures/state.json
@@ -36,6 +36,19 @@
     "readwrite": 0,
     "unit": ""
   },
+  "902": {
+    "name": "Cooling circuit 1 - Comfort setpoint",
+    "dataType_name": "TEMP",
+    "dataType_family": "VALS",
+    "error": 0,
+    "value": "21.0",
+    "desc": "",
+    "precision": 0.1,
+    "dataType": 0,
+    "readonly": 0,
+    "readwrite": 0,
+    "unit": "°C"
+  },
   "8000": {
     "name": "Status heating circuit 1",
     "dataType_name": "ENUM",

--- a/tests/fixtures/state_circuit2.json
+++ b/tests/fixtures/state_circuit2.json
@@ -36,6 +36,19 @@
     "readwrite": 0,
     "unit": ""
   },
+  "1202": {
+    "name": "Cooling circuit 2 - Comfort setpoint",
+    "dataType_name": "TEMP",
+    "dataType_family": "VALS",
+    "error": 0,
+    "value": "24.0",
+    "desc": "",
+    "precision": 0.1,
+    "dataType": 0,
+    "readonly": 0,
+    "readwrite": 0,
+    "unit": "°C"
+  },
   "8001": {
     "name": "Status heating circuit 2",
     "dataType_name": "ENUM",

--- a/tests/fixtures/static_state.json
+++ b/tests/fixtures/static_state.json
@@ -1,16 +1,37 @@
 {
-  "min_temp": {
+  "712": {
+    "name": "Room temp reduced setpoint",
+    "unit": "°C",
+    "desc": "",
+    "value": "17.0",
+    "dataType": 0
+  },
+  "714": {
     "name": "Room temp protective setpoint cooling circuit 1",
     "unit": "°C",
     "desc": "",
     "value": "8.0",
     "dataType": 0
   },
-  "max_temp": {
-    "name": "Summer/winter changeover temp",
+  "716": {
+    "name": "Comfort setpoint max",
     "unit": "°C",
     "desc": "",
-    "value": "20.0",
+    "value": "23.0",
+    "dataType": 0
+  },
+  "905": {
+    "name": "Comfort setpoint min cooling circuit 1",
+    "unit": "°C",
+    "desc": "",
+    "value": "18.0",
+    "dataType": 0
+  },
+  "903": {
+    "name": "Room temp reduced setpoint",
+    "unit": "°C",
+    "desc": "",
+    "value": "26.0",
     "dataType": 0
   }
 }

--- a/tests/fixtures/static_state_circuit2.json
+++ b/tests/fixtures/static_state_circuit2.json
@@ -1,16 +1,37 @@
 {
-  "min_temp": {
+  "1012": {
+    "name": "Room temp reduced setpoint",
+    "unit": "°C",
+    "desc": "",
+    "value": "16.0",
+    "dataType": 0
+  },
+  "1014": {
     "name": "Room temp protective setpoint cooling circuit 2",
     "unit": "°C",
     "desc": "",
     "value": "8.0",
     "dataType": 0
   },
-  "max_temp": {
+  "1016": {
     "name": "Comfort setpoint max",
     "unit": "°C",
     "desc": "",
     "value": "28.0",
+    "dataType": 0
+  },
+  "1205": {
+    "name": "Comfort setpoint min cooling circuit 2",
+    "unit": "°C",
+    "desc": "",
+    "value": "18.0",
+    "dataType": 0
+  },
+  "1203": {
+    "name": "Room temp reduced setpoint",
+    "unit": "°C",
+    "desc": "",
+    "value": "26.0",
     "dataType": 0
   }
 }

--- a/tests/test_api_initialization.py
+++ b/tests/test_api_initialization.py
@@ -7,7 +7,7 @@ import pytest
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_VERSIONS,
+    API_V3,
 )
 from bsblan.exceptions import BSBLANError
 
@@ -24,14 +24,14 @@ async def test_request_no_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_data_initialized_from_versions() -> None:
+async def test_api_data_initialized_from_default_config() -> None:
     """Test that API data is initialized via _setup_api_validator."""
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
         # Set up client with minimal state
-        client._api_version = "v1"
+        client._api_version = "v3"
         client._api_data = None  # This should be initialized
 
         # Call _setup_api_validator which should initialize _api_data
@@ -39,8 +39,8 @@ async def test_api_data_initialized_from_versions() -> None:
 
         # Verify API data was initialized (should be a copy, not the same object)
         assert client._api_data is not None
-        # Verify it started with the same keys as API_VERSIONS["v1"]
-        assert set(client._api_data.keys()) == set(API_VERSIONS["v1"].keys())
+        # Verify it started with the same keys as API_V3
+        assert set(client._api_data.keys()) == set(API_V3.keys())
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -17,7 +17,7 @@ import pytest
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_VERSIONS,
+    API_V3,
     APIConfig,
     ErrorMsg,
 )
@@ -195,9 +195,9 @@ async def test_validate_section_already_validated(monkeypatch: Any) -> None:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v1"
+        client._api_version = "v3"
         # Deep copy to avoid modifying the shared constant
-        source_config = API_VERSIONS["v1"]
+        source_config = API_V3
         client._api_data = cast(
             "APIConfig",
             {
@@ -229,9 +229,9 @@ async def test_validation_error_resets_section(monkeypatch: Any) -> None:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v1"
+        client._api_version = "v3"
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_VERSIONS["v1"]
+        source_config = API_V3
         client._api_data = cast(
             "APIConfig",
             {

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -36,7 +36,7 @@ async def mock_bsblan_circuit() -> AsyncGenerator[BSBLAN, None]:
         bsblan._firmware_version = "1.0.38-20200730234859"
         bsblan._api_version = "v3"
         bsblan._api_data = build_api_config("v3")
-        bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+        bsblan._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
         bsblan._circuit_temp_initialized.add(1)
 
         api_validator = APIValidator(bsblan._api_data)
@@ -144,6 +144,8 @@ async def test_state_circuit2(monkeypatch: Any) -> None:
         assert state.hvac_mode.desc == "Automatic"
         assert state.current_temperature is not None
         assert state.current_temperature.value == 18.5
+        assert state.target_temperature_high is not None
+        assert state.target_temperature_high.value == 24.0
 
 
 @pytest.mark.asyncio
@@ -224,9 +226,15 @@ async def test_static_values_circuit2(monkeypatch: Any) -> None:
 
         assert isinstance(static, StaticState)
         assert static.min_temp is not None
-        assert static.min_temp.value == 8.0
+        assert static.min_temp.value == 16.0
         assert static.max_temp is not None
         assert static.max_temp.value == 28.0
+        assert static.heating_protective_setpoint is not None
+        assert static.heating_protective_setpoint.value == 8.0
+        assert static.cooling_comfort_setpoint_min is not None
+        assert static.cooling_comfort_setpoint_min.value == 18.0
+        assert static.cooling_reduced_setpoint is not None
+        assert static.cooling_reduced_setpoint.value == 26.0
 
 
 # --- Thermostat tests ---
@@ -240,7 +248,7 @@ async def test_thermostat_circuit2_temperature(
     """Test setting temperature on circuit 2."""
     # Set up HC2 temp range
     mock_bsblan_circuit._circuit_temp_ranges[2] = {
-        "min": 8.0,
+        "min": 16.0,
         "max": 28.0,
     }
     mock_bsblan_circuit._circuit_temp_initialized.add(2)
@@ -270,7 +278,7 @@ async def test_thermostat_circuit2_hvac_mode(
     """Test setting HVAC mode on circuit 2."""
     # Set up HC2 temp range
     mock_bsblan_circuit._circuit_temp_ranges[2] = {
-        "min": 8.0,
+        "min": 16.0,
         "max": 28.0,
     }
     mock_bsblan_circuit._circuit_temp_initialized.add(2)
@@ -315,7 +323,7 @@ async def test_thermostat_circuit2_invalid_temperature(
 ) -> None:
     """Test setting out-of-range temperature on circuit 2."""
     mock_bsblan_circuit._circuit_temp_ranges[2] = {
-        "min": 8.0,
+        "min": 16.0,
         "max": 28.0,
     }
     mock_bsblan_circuit._circuit_temp_initialized.add(2)
@@ -387,7 +395,7 @@ async def test_thermostat_circuit2_no_params(
 ) -> None:
     """Test that multi-parameter error still works with circuit."""
     mock_bsblan_circuit._circuit_temp_ranges[2] = {
-        "min": 8.0,
+        "min": 16.0,
         "max": 28.0,
     }
     mock_bsblan_circuit._circuit_temp_initialized.add(2)
@@ -398,19 +406,50 @@ async def test_thermostat_circuit2_no_params(
 
 
 @pytest.mark.asyncio
-async def test_thermostat_circuit2_rejects_cooling_temperature(
+async def test_thermostat_circuit2_cooling_temperature(
+    mock_bsblan_circuit: BSBLAN,
+    aresponses: ResponsesMockServer,
+) -> None:
+    """Test setting cooling temperature on circuit 2."""
+    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+        "min": 16.0,
+        "max": 28.0,
+        "cooling_min": 18.0,
+        "cooling_max": 26.0,
+    }
+    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+
+    expected_data = {
+        "Parameter": "1202",
+        "Value": "24",
+        "Type": "1",
+    }
+    aresponses.add(
+        "example.com",
+        "/JS",
+        "POST",
+        create_response_handler(expected_data),
+    )
+    await mock_bsblan_circuit.thermostat(
+        target_temperature_high="24",
+        circuit=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_thermostat_circuit2_invalid_cooling_temperature(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:
-    """Test cooling target writes are only mapped for circuit 1."""
+    """Test setting out-of-range cooling temperature on circuit 2."""
     mock_bsblan_circuit._circuit_temp_ranges[2] = {
-        "min": 8.0,
-        "max": 28.0,
+        "cooling_min": 18.0,
+        "cooling_max": 26.0,
     }
     mock_bsblan_circuit._circuit_temp_initialized.add(2)
 
     with pytest.raises(BSBLANInvalidParameterError):
         await mock_bsblan_circuit.thermostat(
-            target_temperature_high="24",
+            target_temperature_high="17",
             circuit=2,
         )
 
@@ -451,15 +490,17 @@ async def test_circuit2_temp_range_initialization(
         await bsblan._initialize_temperature_range(circuit=2)
 
         assert 2 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[2]["min"] == 8.0
+        assert bsblan._circuit_temp_ranges[2]["min"] == 16.0
         assert bsblan._circuit_temp_ranges[2]["max"] == 28.0
+        assert bsblan._circuit_temp_ranges[2]["cooling_min"] == 18.0
+        assert bsblan._circuit_temp_ranges[2]["cooling_max"] == 26.0
 
 
 @pytest.mark.asyncio
-async def test_circuit1_temp_range_unchanged(
+async def test_circuit1_temp_range_uses_reduced_lower_bound(
     monkeypatch: Any,
 ) -> None:
-    """Test that HC1 temp range still uses legacy fields."""
+    """Test that HC1 temp range uses the reduced setpoint lower bound."""
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
@@ -485,8 +526,11 @@ async def test_circuit1_temp_range_unchanged(
         await bsblan._initialize_temperature_range(circuit=1)
 
         assert 1 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[1]["min"] == 8.0
-        assert bsblan._circuit_temp_ranges[1]["max"] == 20.0
+        assert bsblan._circuit_temp_ranges[1]["min"] == 17.0
+        assert bsblan._circuit_temp_ranges[1]["max"] == 23.0
+
+        with pytest.raises(BSBLANInvalidParameterError):
+            await bsblan._validate_target_temperature("16.5", circuit=1)
 
 
 @pytest.mark.asyncio
@@ -540,7 +584,7 @@ async def test_thermostat_circuit2_lazy_temp_init(
 
         # Verify it was initialized
         assert 2 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[2]["min"] == 8.0
+        assert bsblan._circuit_temp_ranges[2]["min"] == 16.0
         assert bsblan._circuit_temp_ranges[2]["max"] == 28.0
 
 
@@ -573,6 +617,7 @@ async def test_get_available_circuits_two_circuits(
 
     circuits = await bsblan.get_available_circuits()
     assert circuits == [1, 2]
+    assert bsblan._available_circuits == {1, 2}
     assert [
         call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
     ] == ["700", "1000"]
@@ -603,6 +648,7 @@ async def test_get_available_circuits_only_one(
 
     circuits = await bsblan.get_available_circuits()
     assert circuits == [1]
+    assert bsblan._available_circuits == {1}
     assert [
         call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
     ] == ["700", "1000"]
@@ -715,9 +761,32 @@ async def test_get_available_circuits_all_probes_missing(
 
     circuits = await bsblan.get_available_circuits()
     assert circuits == []
+    assert bsblan._available_circuits == set()
     assert [
         call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
     ] == expected_params
+
+
+@pytest.mark.asyncio
+async def test_temperature_range_skips_unavailable_discovered_circuit(
+    mock_bsblan_circuit: BSBLAN,
+) -> None:
+    """Test temp range init skips circuits known unavailable from discovery."""
+    bsblan = mock_bsblan_circuit
+    bsblan._available_circuits = {1}
+    request_mock = AsyncMock(return_value={})
+    bsblan._request = request_mock  # type: ignore[method-assign]
+
+    await bsblan._initialize_temperature_range(circuit=2)
+
+    assert 2 in bsblan._circuit_temp_initialized
+    assert bsblan._circuit_temp_ranges[2] == {
+        "min": None,
+        "max": None,
+        "cooling_min": None,
+        "cooling_max": None,
+    }
+    request_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -397,6 +397,24 @@ async def test_thermostat_circuit2_no_params(
     assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER
 
 
+@pytest.mark.asyncio
+async def test_thermostat_circuit2_rejects_cooling_temperature(
+    mock_bsblan_circuit: BSBLAN,
+) -> None:
+    """Test cooling target writes are only mapped for circuit 1."""
+    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+        "min": 8.0,
+        "max": 28.0,
+    }
+    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+
+    with pytest.raises(BSBLANInvalidParameterError):
+        await mock_bsblan_circuit.thermostat(
+            target_temperature_high="24",
+            circuit=2,
+        )
+
+
 # --- Temperature range initialization tests ---
 
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -21,17 +21,17 @@ from bsblan.constants import (
     [
         (
             "v1",
-            {"700", "710", "714", "730"},  # hvac_mode, target_temp, min_temp, v1_max
+            {"700", "710", "902", "714", "730"},
             {"770", "716"},  # v3_boost, v3_max_temp
         ),
         (
             "v3",
-            {"700", "710", "714", "770", "716"},  # base + v3 extensions
+            {"700", "710", "902", "714", "770", "716"},
             {"730"},  # v1_max_temp
         ),
         (
             "v5",  # Unknown version
-            {"700", "710", "714"},  # only base parameters
+            {"700", "710", "902", "714"},  # only base parameters
             {"770", "730", "716"},  # no extensions
         ),
     ],
@@ -136,6 +136,15 @@ def test_hot_water_parameter_groups_total_count() -> None:
         + len(HotWaterParams.SCHEDULE)
     )
     assert total_grouped == len(BASE_HOT_WATER_PARAMS)
+
+
+def test_cooling_target_uses_single_base_parameter() -> None:
+    """Test cooling setpoint uses 902, not duplicate decimal parameters."""
+    config = build_api_config("v3")
+
+    assert config["heating"]["902"] == "target_temperature_high"
+    assert "902.1" not in config["heating"]
+    assert "902.2" not in config["heating"]
 
 
 @pytest.mark.parametrize("version", ["v1", "v3"])

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,7 +5,6 @@ import pytest
 import bsblan
 import bsblan.constants
 from bsblan.constants import (
-    API_V1,
     API_V3,
     BASE_HOT_WATER_PARAMS,
     HeatingCircuitStatus,
@@ -16,33 +15,22 @@ from bsblan.constants import (
 )
 
 
-@pytest.mark.parametrize(
-    ("version", "expected_includes", "expected_excludes"),
-    [
-        (
-            "v1",
-            {"700", "710", "902", "714", "730"},
-            {"770", "716"},  # v3_boost, v3_max_temp
-        ),
-        (
-            "v3",
-            {"700", "710", "902", "714", "770", "716"},
-            {"730"},  # v1_max_temp
-        ),
-        (
-            "v5",  # Unknown version
-            {"700", "710", "902", "714"},  # only base parameters
-            {"770", "730", "716"},  # no extensions
-        ),
-    ],
-)
-def test_build_api_config_versions(
-    version: str,
-    expected_includes: set[str],
-    expected_excludes: set[str],
-) -> None:
-    """Test building API config for different versions."""
-    config = build_api_config(version)
+def test_build_api_config_defaults_to_v3() -> None:
+    """Test building the supported v3 API config by default."""
+    config = build_api_config()
+
+    expected_includes = {
+        "700",
+        "710",
+        "770",
+        "902",
+        "712",
+        "714",
+        "716",
+        "905",
+        "903",
+    }
+    expected_excludes = {"730"}  # summer/winter limit, not comfort max
 
     # Check expected parameters are included
     for param_id in expected_includes:
@@ -52,36 +40,32 @@ def test_build_api_config_versions(
             | config["device"]
             | config["sensor"]
             | config["hot_water"]
-        ), f"Parameter {param_id} missing in {version} config"
+        ), f"Parameter {param_id} missing in the v3 config"
 
     # Check excluded parameters are not included
     for param_id in expected_excludes:
         assert param_id not in (config["heating"] | config["staticValues"]), (
-            f"Parameter {param_id} should not be in {version} config"
+            f"Parameter {param_id} should not be in the v3 config"
         )
 
+    assert build_api_config("v3") == config
 
-@pytest.mark.parametrize(
-    ("api_config", "should_have", "should_not_have"),
-    [
-        (API_V1, {"730"}, {"770", "716"}),  # V1 has 730, not 770/716
-        (API_V3, {"770", "716"}, {"730"}),  # V3 has 770/716, not 730
-    ],
-)
-def test_pre_built_api_configurations(
-    api_config: dict[str, dict[str, str]],
-    should_have: set[str],
-    should_not_have: set[str],
-) -> None:
-    """Test that pre-built API configurations are correct."""
-    all_params = set(api_config["heating"].keys()) | set(
-        api_config["staticValues"].keys()
-    )
 
-    for param_id in should_have:
+@pytest.mark.parametrize("version", ["v1", "v5"])
+def test_build_api_config_rejects_unsupported_versions(version: str) -> None:
+    """Test that only API v3 can be built."""
+    with pytest.raises(ValueError, match="Only API version v3 is supported"):
+        build_api_config(version)
+
+
+def test_pre_built_api_configuration() -> None:
+    """Test that the pre-built API configuration is correct."""
+    all_params = set(API_V3["heating"].keys()) | set(API_V3["staticValues"].keys())
+
+    for param_id in ("770", "716"):
         assert param_id in all_params
 
-    for param_id in should_not_have:
+    for param_id in ("730",):
         assert param_id not in all_params
 
 
@@ -140,17 +124,29 @@ def test_hot_water_parameter_groups_total_count() -> None:
 
 def test_cooling_target_uses_single_base_parameter() -> None:
     """Test cooling setpoint uses 902, not duplicate decimal parameters."""
-    config = build_api_config("v3")
+    config = build_api_config()
 
     assert config["heating"]["902"] == "target_temperature_high"
+    assert config["heating_circuit2"]["1202"] == "target_temperature_high"
+    assert config["staticValues"]["712"] == "min_temp"
+    assert config["staticValues"]["714"] == "heating_protective_setpoint"
+    assert config["staticValues"]["716"] == "max_temp"
+    assert config["staticValues"]["905"] == "cooling_comfort_setpoint_min"
+    assert config["staticValues"]["903"] == "cooling_reduced_setpoint"
+    assert config["staticValues_circuit2"]["1012"] == "min_temp"
+    assert config["staticValues_circuit2"]["1014"] == ("heating_protective_setpoint")
+    assert config["staticValues_circuit2"]["1016"] == "max_temp"
+    assert config["staticValues_circuit2"]["1205"] == ("cooling_comfort_setpoint_min")
+    assert config["staticValues_circuit2"]["1203"] == "cooling_reduced_setpoint"
+    assert "908" not in config["staticValues"]
+    assert "1208" not in config["staticValues_circuit2"]
     assert "902.1" not in config["heating"]
     assert "902.2" not in config["heating"]
 
 
-@pytest.mark.parametrize("version", ["v1", "v3"])
-def test_api_config_structure(version: str) -> None:
+def test_api_config_structure() -> None:
     """Test that API config has required structure."""
-    config = build_api_config(version)
+    config = build_api_config()
 
     # Check all required sections exist
     required_sections = {

--- a/tests/test_include_parameter.py
+++ b/tests/test_include_parameter.py
@@ -392,11 +392,11 @@ async def test_static_values_with_include(monkeypatch: Any) -> None:
         bsblan._api_validator = api_validator
 
         partial_response = {
-            "714": {
-                "name": "Min temp",
+            "712": {
+                "name": "Room temp reduced setpoint",
                 "unit": "°C",
                 "desc": "",
-                "value": "8.0",
+                "value": "17.0",
                 "dataType": 0,
                 "error": 0,
                 "readonly": 0,

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -16,20 +16,18 @@ from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
     ErrorMsg,
 )
-from bsblan.exceptions import BSBLANError
+from bsblan.exceptions import BSBLANError, BSBLANVersionError
 
 
 @pytest.mark.asyncio
-async def test_copy_api_config_v1() -> None:
-    """Test _copy_api_config with v1 version."""
+async def test_copy_api_config_rejects_unsupported_version() -> None:
+    """Test _copy_api_config rejects unsupported API versions."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._api_version = "v1"
 
-        api_data = bsblan._copy_api_config()
-
-        # Verify API data was created
-        assert api_data is not None
+        with pytest.raises(BSBLANVersionError):
+            bsblan._copy_api_config()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -281,6 +281,22 @@ async def test_pps_thermostat_temperature_writes_comfort_setpoint(
 
 
 @pytest.mark.asyncio
+async def test_pps_thermostat_rejects_cooling_temperature(
+    pps_bsblan: BSBLAN,
+) -> None:
+    """Test PPS climate rejects cooling target writes."""
+    pps_bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+    pps_bsblan._circuit_temp_initialized.add(1)
+    request_mock = AsyncMock(return_value={"status": "ok"})
+    pps_bsblan._request = request_mock  # type: ignore[method-assign]
+
+    with pytest.raises(BSBLANInvalidParameterError, match="target_temperature_high"):
+        await pps_bsblan.thermostat(target_temperature_high="24.0")
+
+    request_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_pps_thermostat_rejects_unsupported_eco_mode(
     pps_bsblan: BSBLAN,
 ) -> None:
@@ -336,6 +352,7 @@ async def test_pps_circuit_discovery_returns_single_climate(
     circuits = await pps_bsblan.get_available_circuits()
 
     assert circuits == [1]
+    assert pps_bsblan._available_circuits == {1}
     request_mock.assert_awaited_once_with(params={"Parameter": "15000"})
 
 
@@ -351,6 +368,8 @@ async def test_pps_circuit_discovery_returns_empty_without_mode(
     circuits = await pps_bsblan.get_available_circuits()
 
     assert circuits == []
+    assert pps_bsblan._available_circuits == set()
+    assert pps_bsblan._available_circuits == set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -369,7 +369,6 @@ async def test_pps_circuit_discovery_returns_empty_without_mode(
 
     assert circuits == []
     assert pps_bsblan._available_circuits == set()
-    assert pps_bsblan._available_circuits == set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -148,7 +148,11 @@ async def test_state_without_cooling_strips_target_temperature_high(
 
         assert state.hvac_mode is not None
         assert state.target_temperature_high is None
-        assert bsblan.get_parameter_id("target_temperature_high") is None
+        assert bsblan._api_data is not None
+        assert "902" not in bsblan._api_data["heating"]
+        assert bsblan._api_data["heating_circuit2"]["1202"] == (
+            "target_temperature_high"
+        )
         assert [
             call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
         ] == ["700,902", "700"]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -59,6 +59,12 @@ async def test_state(monkeypatch: Any) -> None:
         assert state.target_temperature.desc == ""
         assert state.target_temperature.unit == "°C"
 
+        # Cooling target temperature assertions
+        assert state.target_temperature_high is not None
+        assert state.target_temperature_high.value == 21.0
+        assert state.target_temperature_high.desc == ""
+        assert state.target_temperature_high.unit == "°C"
+
     # HVAC mode changeover assertions
     assert state.hvac_mode_changeover is not None
     assert state.hvac_mode_changeover.value == 2
@@ -81,5 +87,68 @@ async def test_state(monkeypatch: Any) -> None:
 
     # Verify API call
     request_mock.assert_called_once_with(
-        params={"Parameter": "700,710,900,8000,8740,770"}
+        params={"Parameter": "700,710,900,902,8000,8740,770"}
     )
+
+
+@pytest.mark.asyncio
+async def test_state_with_cooling_include(monkeypatch: Any) -> None:
+    """Test fetching only the cooling target temperature."""
+    async with aiohttp.ClientSession() as session:
+        config = BSBLANConfig(host="example.com")
+        bsblan = BSBLAN(config, session=session)
+
+        monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
+        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+
+        api_validator = APIValidator(API_V3)
+        api_validator.validated_sections.add("heating")
+        bsblan._api_validator = api_validator
+
+        state_data = json.loads(load_fixture("state.json"))
+        request_mock: AsyncMock = AsyncMock(return_value={"902": state_data["902"]})
+        monkeypatch.setattr(bsblan, "_request", request_mock)
+
+        state: State = await bsblan.state(include=["target_temperature_high"])
+
+        assert state.target_temperature_high is not None
+        assert state.target_temperature_high.value == 21.0
+        assert state.target_temperature is None
+        request_mock.assert_awaited_once_with(params={"Parameter": "902"})
+
+
+@pytest.mark.asyncio
+async def test_state_without_cooling_strips_target_temperature_high(
+    monkeypatch: Any,
+) -> None:
+    """Test unsupported cooling setpoint is stripped during validation."""
+    async with aiohttp.ClientSession() as session:
+        config = BSBLANConfig(host="example.com")
+        bsblan = BSBLAN(config, session=session)
+
+        monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
+        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        bsblan._api_data = {
+            section: params.copy() for section, params in API_V3.items()
+        }
+        bsblan._api_validator = APIValidator(bsblan._api_data)
+
+        state_data = json.loads(load_fixture("state.json"))
+        validation_response = {"700": state_data["700"]}
+        fetch_response = {"700": state_data["700"]}
+        request_mock: AsyncMock = AsyncMock(
+            side_effect=[validation_response, fetch_response]
+        )
+        monkeypatch.setattr(bsblan, "_request", request_mock)
+
+        state: State = await bsblan.state(
+            include=["hvac_mode", "target_temperature_high"]
+        )
+
+        assert state.hvac_mode is not None
+        assert state.target_temperature_high is None
+        assert bsblan.get_parameter_id("target_temperature_high") is None
+        assert [
+            call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
+        ] == ["700,902", "700"]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -86,7 +86,7 @@ async def test_state(monkeypatch: Any) -> None:
     assert state.room1_temp_setpoint_boost.unit == "°C"
 
     # Verify API call
-    request_mock.assert_called_once_with(
+    request_mock.assert_awaited_once_with(
         params={"Parameter": "700,710,900,902,8000,8740,770"}
     )
 

--- a/tests/test_static_state.py
+++ b/tests/test_static_state.py
@@ -41,6 +41,12 @@ async def test_sensor(monkeypatch: Any) -> None:
         static: StaticState = await bsblan.static_values()
         assert isinstance(static, StaticState)
         assert static.min_temp is not None
-        assert static.min_temp.value == 8.0
+        assert static.min_temp.value == 17.0
         assert static.max_temp is not None
-        assert static.max_temp.value == 20.0
+        assert static.max_temp.value == 23.0
+        assert static.heating_protective_setpoint is not None
+        assert static.heating_protective_setpoint.value == 8.0
+        assert static.cooling_comfort_setpoint_min is not None
+        assert static.cooling_comfort_setpoint_min.value == 18.0
+        assert static.cooling_reduced_setpoint is not None
+        assert static.cooling_reduced_setpoint.value == 26.0

--- a/tests/test_temperature_unit.py
+++ b/tests/test_temperature_unit.py
@@ -43,6 +43,8 @@ async def test_initialize_temperature_range_celsius() -> None:
         # Verify temperature range was set correctly
         assert bsblan._circuit_temp_ranges[1]["min"] == 10.0
         assert bsblan._circuit_temp_ranges[1]["max"] == 30.0
+        assert bsblan._circuit_temp_ranges[1]["cooling_min"] is None
+        assert bsblan._circuit_temp_ranges[1]["cooling_max"] is None
         assert 1 in bsblan._circuit_temp_initialized
 
 
@@ -65,6 +67,8 @@ async def test_initialize_temperature_range_fahrenheit() -> None:
         # Verify temperature range was set correctly
         assert bsblan._circuit_temp_ranges[1]["min"] == 50.0
         assert bsblan._circuit_temp_ranges[1]["max"] == 86.0
+        assert bsblan._circuit_temp_ranges[1]["cooling_min"] is None
+        assert bsblan._circuit_temp_ranges[1]["cooling_max"] is None
         assert 1 in bsblan._circuit_temp_initialized
 
 
@@ -94,6 +98,8 @@ async def test_initialize_temperature_range_alternate_celsius_format() -> None:
         # Verify temperature range was set correctly
         assert bsblan._circuit_temp_ranges[1]["min"] == 10.0
         assert bsblan._circuit_temp_ranges[1]["max"] == 30.0
+        assert bsblan._circuit_temp_ranges[1]["cooling_min"] is None
+        assert bsblan._circuit_temp_ranges[1]["cooling_max"] is None
         assert 1 in bsblan._circuit_temp_initialized
 
 

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.constants import API_VERSIONS, APIConfig
+from bsblan.constants import API_V3, APIConfig
 from bsblan.exceptions import BSBLANError, BSBLANInvalidParameterError
 from bsblan.utility import APIValidator
 
@@ -79,15 +79,70 @@ async def test_validate_target_temperature_valid() -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_target_temperature_high_no_range() -> None:
+    """Test cooling target validation when no cooling bounds are available."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    async def mock_init_temp_range(circuit: int = 1) -> None:
+        pass
+
+    bsblan._initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
+
+    await bsblan._validate_target_temperature_high("32.0")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_temperature_high_invalid_value() -> None:
+    """Test cooling target validation with invalid non-numeric value."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._circuit_temp_ranges[1] = {"cooling_min": 18.0, "cooling_max": 26.0}
+    bsblan._circuit_temp_initialized.add(1)
+
+    with pytest.raises(BSBLANInvalidParameterError):
+        await bsblan._validate_target_temperature_high("invalid")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_temperature_high_out_of_range() -> None:
+    """Test cooling target validation with value outside cooling bounds."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._circuit_temp_ranges[1] = {"cooling_min": 18.0, "cooling_max": 26.0}
+    bsblan._circuit_temp_initialized.add(1)
+
+    with pytest.raises(BSBLANInvalidParameterError):
+        await bsblan._validate_target_temperature_high("17.5")
+
+    with pytest.raises(BSBLANInvalidParameterError):
+        await bsblan._validate_target_temperature_high("26.5")
+
+
+@pytest.mark.asyncio
+async def test_validate_target_temperature_high_valid() -> None:
+    """Test cooling target validation with value inside cooling bounds."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._circuit_temp_ranges[1] = {"cooling_min": 18.0, "cooling_max": 26.0}
+    bsblan._circuit_temp_initialized.add(1)
+
+    await bsblan._validate_target_temperature_high("21.0")
+
+
+@pytest.mark.asyncio
 async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> None:
     """Test warning when min_temp is not available from device (line 332)."""
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v1"
+        client._api_version = "v3"
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_VERSIONS["v1"]
+        source_config = API_V3
         client._api_data = cast(
             "APIConfig",
             {
@@ -119,9 +174,9 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v1"
+        client._api_version = "v3"
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_VERSIONS["v1"]
+        source_config = API_V3
         client._api_data = cast(
             "APIConfig",
             {
@@ -153,9 +208,9 @@ async def test_temperature_range_static_values_error(monkeypatch: Any) -> None:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v1"
+        client._api_version = "v3"
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_VERSIONS["v1"]
+        source_config = API_V3
         client._api_data = cast(
             "APIConfig",
             {

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -118,6 +118,26 @@ async def test_change_temperature(
 
 
 @pytest.mark.asyncio
+async def test_change_cooling_temperature(
+    mock_bsblan: BSBLAN,
+    mock_aresponses: ResponsesMockServer,
+) -> None:
+    """Test changing BSBLAN cooling setpoint."""
+    expected_data = {
+        "Parameter": "902",
+        "Value": "32.0",
+        "Type": "1",
+    }
+    mock_aresponses.add(
+        "example.com",
+        "/JS",
+        "POST",
+        create_response_handler(expected_data),
+    )
+    await mock_bsblan.thermostat(target_temperature_high=32.0)
+
+
+@pytest.mark.asyncio
 async def test_change_hvac_mode(
     mock_bsblan: BSBLAN,
     mock_aresponses: ResponsesMockServer,
@@ -142,6 +162,13 @@ async def test_invalid_temperature(mock_bsblan: BSBLAN) -> None:
     """Test setting an invalid temperature."""
     with pytest.raises(BSBLANInvalidParameterError):
         await mock_bsblan.thermostat(target_temperature="35")
+
+
+@pytest.mark.asyncio
+async def test_invalid_cooling_temperature(mock_bsblan: BSBLAN) -> None:
+    """Test setting an invalid cooling temperature."""
+    with pytest.raises(BSBLANInvalidParameterError):
+        await mock_bsblan.thermostat(target_temperature_high="invalid")
 
 
 @pytest.mark.asyncio
@@ -190,4 +217,17 @@ async def test_no_parameters(mock_bsblan: BSBLAN) -> None:
     """Test calling thermostat without parameters."""
     with pytest.raises(BSBLANError) as exc_info:
         await mock_bsblan.thermostat()
+    assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER
+
+
+@pytest.mark.asyncio
+async def test_cooling_temperature_with_other_parameter_raises(
+    mock_bsblan: BSBLAN,
+) -> None:
+    """Test cooling setpoint respects one-parameter-per-call rule."""
+    with pytest.raises(BSBLANError) as exc_info:
+        await mock_bsblan.thermostat(
+            target_temperature="20",
+            target_temperature_high="24",
+        )
     assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -42,7 +42,7 @@ async def mock_bsblan() -> AsyncGenerator[BSBLAN, None]:
         bsblan = BSBLAN(config, session=session)
         bsblan._firmware_version = "1.0.38-20200730234859"
         bsblan._api_version = "v3"
-        bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+        bsblan._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
         bsblan._circuit_temp_initialized.add(1)
         yield bsblan
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -48,7 +48,8 @@ def validator() -> APIValidator:
             # Add other parameters as needed
         },
         "staticValues": {
-            "714": "min_temp",
+            "712": "min_temp",
+            "714": "heating_protective_setpoint",
             "716": "max_temp",
             # Add other parameters as needed
         },

--- a/tests/test_utility_additional.py
+++ b/tests/test_utility_additional.py
@@ -41,7 +41,8 @@ def fresh_api_validator() -> APIValidator:
             "710": "target_temperature",
         },
         "staticValues": {
-            "714": "min_temp",
+            "712": "min_temp",
+            "714": "heating_protective_setpoint",
             "716": "max_temp",
         },
         "hot_water": {

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -50,6 +50,19 @@ async def test_set_api_version_rejects_legacy_firmware() -> None:
 
 
 @pytest.mark.asyncio
+async def test_set_api_version_invalid_firmware_string() -> None:
+    """Test non-PEP440 firmware strings raise BSBLANVersionError."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    # Firmware strings with build metadata are not PEP 440 compliant
+    bsblan._firmware_version = "1.0.38-not-a-version"
+
+    with pytest.raises(BSBLANVersionError):
+        bsblan._set_api_version()
+
+
+@pytest.mark.asyncio
 async def test_set_api_version_v3() -> None:
     """Test setting API version with v3 compatible firmware."""
     config = BSBLANConfig(host="example.com")

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -37,16 +37,16 @@ async def test_set_api_version_unsupported() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_api_version_v1() -> None:
-    """Test setting API version with v1 compatible firmware."""
+async def test_set_api_version_rejects_legacy_firmware() -> None:
+    """Test legacy firmware that previously mapped to v1 is unsupported."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Set firmware version to v1 compatible
+    # Set firmware version to legacy v1-compatible firmware
     bsblan._firmware_version = "1.0.0"
-    bsblan._set_api_version()
 
-    assert bsblan._api_version == "v1"
+    with pytest.raises(BSBLANVersionError):
+        bsblan._set_api_version()
 
 
 @pytest.mark.asyncio
@@ -90,7 +90,9 @@ async def test_setup_api_validator_no_api_version() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # API version is None by default
+    # Force API version to None to test the defensive error path
+    bsblan._api_version = None
+
     with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
         await bsblan._setup_api_validator()
 
@@ -105,7 +107,7 @@ async def test_set_api_version_v5() -> None:
     bsblan._firmware_version = "5.0.16"
     bsblan._set_api_version()
 
-    assert bsblan._api_version == "v3"  # BSB-LAN 5.x uses v3 API with extensions
+    assert bsblan._api_version == "v3"
 
 
 @pytest.mark.asyncio
@@ -118,7 +120,7 @@ async def test_set_api_version_v5_early() -> None:
     bsblan._firmware_version = "5.0.0"
     bsblan._set_api_version()
 
-    assert bsblan._api_version == "v3"  # BSB-LAN 5.x uses v3 API with extensions
+    assert bsblan._api_version == "v3"
 
 
 @pytest.mark.asyncio
@@ -193,11 +195,11 @@ async def test_set_api_version_v5_edge_cases() -> None:
 
 @pytest.mark.asyncio
 async def test_unsupported_version_still_fails() -> None:
-    """Test that unsupported versions between 1.2.0 and 3.0.0 still fail."""
+    """Test that unsupported versions before 3.0.0 still fail."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Test that version 2.0.0 still fails (gap between v1 and v3)
+    # Test that version 2.0.0 still fails
     bsblan._firmware_version = "2.0.0"
 
     with pytest.raises(BSBLANVersionError):


### PR DESCRIPTION
This pull request introduces several documentation improvements, code refactorings, and feature enhancements to support cooling setpoints and simplify the example scripts. The main changes include expanded documentation for temperature and cooling support, a significant refactor of the example scripts to remove unnecessary async usage, and improved parameter fetching capabilities.

**Documentation and Feature Enhancements:**

* Added detailed documentation for temperature bounds, heating and cooling setpoints, and how cooling support is detected and used in the client (`docs/getting-started.md`).
* Updated the feature list to mention detection of optional cooling setpoints and clarified API v3 support (`docs/index.md`).

**Example Script Refactoring and Usability:**

* Refactored `examples/control.py` to remove unnecessary `async` usage in printing functions, simplifying the code and making it easier to read and maintain. Also expanded the static state printout to include cooling bounds and improved hot water configuration display. [[1]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L38-R38) [[2]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L106-R115) [[3]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L136-R185) [[4]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L202-R219) [[5]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L230-R241) [[6]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L256-R296) [[7]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L340-R326) [[8]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L356-R365)

**Parameter Fetching Improvements:**

* Enhanced `examples/fetch_param.py` to support fetching parameter structure (`/JC`) and category dumps (`/JK`), improved CLI argument parsing, and added pretty-printing for API responses. The script now provides clearer instructions and more flexible usage. [[1]](diffhunk://#diff-720b68549713d50056b9f2d033d93fc585aefd4175e739877d6b357a244d0bccL1-R25) [[2]](diffhunk://#diff-720b68549713d50056b9f2d033d93fc585aefd4175e739877d6b357a244d0bccL24-R42) [[3]](diffhunk://#diff-720b68549713d50056b9f2d033d93fc585aefd4175e739877d6b357a244d0bccR55-R161)

**Internal Codebase Maintenance:**

* Minor update in `src/bsblan/bsblan.py` to clean up imports and clarify API version constants.