### PR TITLE
Fix thermostat min-temp regression and clarify setpoint names

### DIFF
--- a/examples/control.py
+++ b/examples/control.py
@@ -203,7 +203,7 @@ def print_static_state(static_state: StaticState) -> None:
         "Reduced Setpoint (eco/night)": get_attribute(
             static_state.temp_reduced_setpoint
         ),
-        "Max Temperature (heating)": get_attribute(static_state.max_temp),
+        "Max Temperature (heating)": get_attribute(static_state.comfort_setpoint_max),
         "Heating Protective Setpoint": get_attribute(
             static_state.heating_protective_setpoint
         ),

--- a/examples/control.py
+++ b/examples/control.py
@@ -192,6 +192,22 @@ def print_device_info(device: Device, info: Info) -> None:
     print_attributes("Device Information", attributes)
 
 
+def _first_temperature_attribute(static_state: StaticState) -> Any:
+    """Return the first available temperature attribute for unit detection."""
+    for attribute in (
+        static_state.heating_protective_setpoint,
+        static_state.temp_reduced_setpoint,
+        static_state.comfort_setpoint_max,
+        static_state.min_temp,
+        static_state.max_temp,
+        static_state.cooling_comfort_setpoint_min,
+        static_state.cooling_reduced_setpoint,
+    ):
+        if attribute is not None:
+            return attribute
+    return None
+
+
 def print_static_state(static_state: StaticState) -> None:
     """Print static state information, including heating and cooling bounds.
 
@@ -203,7 +219,7 @@ def print_static_state(static_state: StaticState) -> None:
         "Reduced Setpoint (eco/night)": get_attribute(
             static_state.temp_reduced_setpoint
         ),
-        "Max Temperature (heating)": get_attribute(static_state.comfort_setpoint_max),
+        "Comfort Setpoint Max": get_attribute(static_state.comfort_setpoint_max),
         "Heating Protective Setpoint": get_attribute(
             static_state.heating_protective_setpoint
         ),
@@ -214,7 +230,7 @@ def print_static_state(static_state: StaticState) -> None:
             static_state.cooling_reduced_setpoint
         ),
         "Temperature Unit": get_attribute(
-            static_state.heating_protective_setpoint, "unit"
+            _first_temperature_attribute(static_state), "unit"
         ),
     }
     print_attributes("Static State", attributes)

--- a/examples/control.py
+++ b/examples/control.py
@@ -200,7 +200,9 @@ def print_static_state(static_state: StaticState) -> None:
 
     """
     attributes = {
-        "Min Temperature (heating)": get_attribute(static_state.min_temp),
+        "Reduced Setpoint (eco/night)": get_attribute(
+            static_state.temp_reduced_setpoint
+        ),
         "Max Temperature (heating)": get_attribute(static_state.max_temp),
         "Heating Protective Setpoint": get_attribute(
             static_state.heating_protective_setpoint
@@ -211,7 +213,9 @@ def print_static_state(static_state: StaticState) -> None:
         "Cooling Setpoint Max (reduced)": get_attribute(
             static_state.cooling_reduced_setpoint
         ),
-        "Temperature Unit": get_attribute(static_state.min_temp, "unit"),
+        "Temperature Unit": get_attribute(
+            static_state.heating_protective_setpoint, "unit"
+        ),
     }
     print_attributes("Static State", attributes)
 

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -631,8 +631,12 @@ class BSBLAN:
             )
             return temp_range
 
-        if static_values.min_temp is not None:
-            temp_range["min"] = static_values.min_temp.value
+        # Prefer heating_protective_setpoint (714/1014) as the true lower bound
+        # for standard circuits. Fall back to min_temp for PPS circuits (15006)
+        # which have no separate protective setpoint.
+        min_source = static_values.heating_protective_setpoint or static_values.min_temp
+        if min_source is not None:
+            temp_range["min"] = min_source.value
             logger.debug(
                 "Circuit %d min temp initialized: %s",
                 circuit,

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -633,8 +633,19 @@ class BSBLAN:
 
         # Prefer heating_protective_setpoint (714/1014) as the true lower bound
         # for standard circuits. Fall back to min_temp for PPS circuits (15006)
-        # which have no separate protective setpoint.
-        min_source = static_values.heating_protective_setpoint or static_values.min_temp
+        # which have no separate protective setpoint. Skip sources whose value is
+        # inactive (BSB-LAN may return "---" which becomes value=None).
+        min_source = next(
+            (
+                source
+                for source in (
+                    static_values.heating_protective_setpoint,
+                    static_values.min_temp,
+                )
+                if source is not None and source.value is not None
+            ),
+            None,
+        )
         if min_source is not None:
             temp_range["min"] = min_source.value
             logger.debug(
@@ -645,8 +656,18 @@ class BSBLAN:
 
         # Prefer comfort_setpoint_max (716/1016) as the upper bound for standard
         # circuits. Fall back to max_temp for PPS circuits (15007) which expose
-        # only a generic max.
-        max_source = static_values.comfort_setpoint_max or static_values.max_temp
+        # only a generic max. Skip sources whose value is inactive.
+        max_source = next(
+            (
+                source
+                for source in (
+                    static_values.comfort_setpoint_max,
+                    static_values.max_temp,
+                )
+                if source is not None and source.value is not None
+            ),
+            None,
+        )
         if max_source is not None:
             temp_range["max"] = max_source.value
             logger.debug(

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -643,8 +643,12 @@ class BSBLAN:
                 temp_range["min"],
             )
 
-        if static_values.max_temp is not None:
-            temp_range["max"] = static_values.max_temp.value
+        # Prefer comfort_setpoint_max (716/1016) as the upper bound for standard
+        # circuits. Fall back to max_temp for PPS circuits (15007) which expose
+        # only a generic max.
+        max_source = static_values.comfort_setpoint_max or static_values.max_temp
+        if max_source is not None:
+            temp_range["max"] = max_source.value
             logger.debug(
                 "Circuit %d max temp initialized: %s",
                 circuit,

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -42,7 +42,7 @@ BASE_HEATING_PARAMS: Final[dict[str, str]] = {
 BASE_STATIC_VALUES_PARAMS: Final[dict[str, str]] = {
     "712": "temp_reduced_setpoint",
     "714": "heating_protective_setpoint",
-    "716": "max_temp",
+    "716": "comfort_setpoint_max",
     "905": "cooling_comfort_setpoint_min",
     "903": "cooling_reduced_setpoint",
 }
@@ -109,7 +109,7 @@ BASE_HEATING_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
 BASE_STATIC_VALUES_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
     "1012": "temp_reduced_setpoint",
     "1014": "heating_protective_setpoint",
-    "1016": "max_temp",
+    "1016": "comfort_setpoint_max",
     "1205": "cooling_comfort_setpoint_min",
     "1203": "cooling_reduced_setpoint",
 }

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -40,7 +40,7 @@ BASE_HEATING_PARAMS: Final[dict[str, str]] = {
 }
 
 BASE_STATIC_VALUES_PARAMS: Final[dict[str, str]] = {
-    "712": "min_temp",
+    "712": "temp_reduced_setpoint",
     "714": "heating_protective_setpoint",
     "716": "max_temp",
     "905": "cooling_comfort_setpoint_min",
@@ -107,7 +107,7 @@ BASE_HEATING_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
 }
 
 BASE_STATIC_VALUES_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
-    "1012": "min_temp",
+    "1012": "temp_reduced_setpoint",
     "1014": "heating_protective_setpoint",
     "1016": "max_temp",
     "1205": "cooling_comfort_setpoint_min",

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -481,11 +481,13 @@ class StaticState(BaseModel):
 
     # 712/1012: room temperature reduced (eco/night) setpoint
     temp_reduced_setpoint: EntityInfo[float] | None = None
-    # 714/1014: frost-protection lower bound; also used by PPS as min_temp (15006)
+    # PPS-only lower bound (15006)
     min_temp: EntityInfo[float] | None = None
-    # 716/1016: comfort setpoint max upper bound; PPS uses max_temp (15007)
+    # 716/1016: comfort setpoint max upper bound
     comfort_setpoint_max: EntityInfo[float] | None = None
+    # PPS-only upper bound (15007)
     max_temp: EntityInfo[float] | None = None
+    # 714/1014: frost-protection lower bound
     heating_protective_setpoint: EntityInfo[float] | None = None
     cooling_comfort_setpoint_min: EntityInfo[float] | None = None
     cooling_reduced_setpoint: EntityInfo[float] | None = None

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -483,6 +483,8 @@ class StaticState(BaseModel):
     temp_reduced_setpoint: EntityInfo[float] | None = None
     # 714/1014: frost-protection lower bound; also used by PPS as min_temp (15006)
     min_temp: EntityInfo[float] | None = None
+    # 716/1016: comfort setpoint max upper bound; PPS uses max_temp (15007)
+    comfort_setpoint_max: EntityInfo[float] | None = None
     max_temp: EntityInfo[float] | None = None
     heating_protective_setpoint: EntityInfo[float] | None = None
     cooling_comfort_setpoint_min: EntityInfo[float] | None = None

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -479,6 +479,9 @@ class State(BaseModel):
 class StaticState(BaseModel):
     """Class for entities that are not changing."""
 
+    # 712/1012: room temperature reduced (eco/night) setpoint
+    temp_reduced_setpoint: EntityInfo[float] | None = None
+    # 714/1014: frost-protection lower bound; also used by PPS as min_temp (15006)
     min_temp: EntityInfo[float] | None = None
     max_temp: EntityInfo[float] | None = None
     heating_protective_setpoint: EntityInfo[float] | None = None

--- a/tests/fixtures/dict_version.json
+++ b/tests/fixtures/dict_version.json
@@ -9,7 +9,7 @@
   "staticValues": {
     "712": "temp_reduced_setpoint",
     "714": "heating_protective_setpoint",
-    "716": "max_temp"
+    "716": "comfort_setpoint_max"
   },
   "device": {
     "6224": "device_identification",

--- a/tests/fixtures/dict_version.json
+++ b/tests/fixtures/dict_version.json
@@ -7,7 +7,7 @@
     "8740": "current_temperature"
   },
   "staticValues": {
-    "712": "min_temp",
+    "712": "temp_reduced_setpoint",
     "714": "heating_protective_setpoint",
     "716": "max_temp"
   },

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -225,8 +225,8 @@ async def test_static_values_circuit2(monkeypatch: Any) -> None:
         static: StaticState = await bsblan.static_values(circuit=2)
 
         assert isinstance(static, StaticState)
-        assert static.min_temp is not None
-        assert static.min_temp.value == 16.0
+        assert static.temp_reduced_setpoint is not None
+        assert static.temp_reduced_setpoint.value == 16.0
         assert static.max_temp is not None
         assert static.max_temp.value == 28.0
         assert static.heating_protective_setpoint is not None
@@ -490,7 +490,7 @@ async def test_circuit2_temp_range_initialization(
         await bsblan._initialize_temperature_range(circuit=2)
 
         assert 2 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[2]["min"] == 16.0
+        assert bsblan._circuit_temp_ranges[2]["min"] == 8.0
         assert bsblan._circuit_temp_ranges[2]["max"] == 28.0
         assert bsblan._circuit_temp_ranges[2]["cooling_min"] == 18.0
         assert bsblan._circuit_temp_ranges[2]["cooling_max"] == 26.0
@@ -526,11 +526,11 @@ async def test_circuit1_temp_range_uses_reduced_lower_bound(
         await bsblan._initialize_temperature_range(circuit=1)
 
         assert 1 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[1]["min"] == 17.0
+        assert bsblan._circuit_temp_ranges[1]["min"] == 8.0
         assert bsblan._circuit_temp_ranges[1]["max"] == 23.0
 
         with pytest.raises(BSBLANInvalidParameterError):
-            await bsblan._validate_target_temperature("16.5", circuit=1)
+            await bsblan._validate_target_temperature("7.5", circuit=1)
 
 
 @pytest.mark.asyncio
@@ -584,7 +584,7 @@ async def test_thermostat_circuit2_lazy_temp_init(
 
         # Verify it was initialized
         assert 2 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[2]["min"] == 16.0
+        assert bsblan._circuit_temp_ranges[2]["min"] == 8.0
         assert bsblan._circuit_temp_ranges[2]["max"] == 28.0
 
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -227,8 +227,8 @@ async def test_static_values_circuit2(monkeypatch: Any) -> None:
         assert isinstance(static, StaticState)
         assert static.temp_reduced_setpoint is not None
         assert static.temp_reduced_setpoint.value == 16.0
-        assert static.max_temp is not None
-        assert static.max_temp.value == 28.0
+        assert static.comfort_setpoint_max is not None
+        assert static.comfort_setpoint_max.value == 28.0
         assert static.heating_protective_setpoint is not None
         assert static.heating_protective_setpoint.value == 8.0
         assert static.cooling_comfort_setpoint_min is not None

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -128,12 +128,12 @@ def test_cooling_target_uses_single_base_parameter() -> None:
 
     assert config["heating"]["902"] == "target_temperature_high"
     assert config["heating_circuit2"]["1202"] == "target_temperature_high"
-    assert config["staticValues"]["712"] == "min_temp"
+    assert config["staticValues"]["712"] == "temp_reduced_setpoint"
     assert config["staticValues"]["714"] == "heating_protective_setpoint"
     assert config["staticValues"]["716"] == "max_temp"
     assert config["staticValues"]["905"] == "cooling_comfort_setpoint_min"
     assert config["staticValues"]["903"] == "cooling_reduced_setpoint"
-    assert config["staticValues_circuit2"]["1012"] == "min_temp"
+    assert config["staticValues_circuit2"]["1012"] == "temp_reduced_setpoint"
     assert config["staticValues_circuit2"]["1014"] == ("heating_protective_setpoint")
     assert config["staticValues_circuit2"]["1016"] == "max_temp"
     assert config["staticValues_circuit2"]["1205"] == ("cooling_comfort_setpoint_min")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -130,12 +130,12 @@ def test_cooling_target_uses_single_base_parameter() -> None:
     assert config["heating_circuit2"]["1202"] == "target_temperature_high"
     assert config["staticValues"]["712"] == "temp_reduced_setpoint"
     assert config["staticValues"]["714"] == "heating_protective_setpoint"
-    assert config["staticValues"]["716"] == "max_temp"
+    assert config["staticValues"]["716"] == "comfort_setpoint_max"
     assert config["staticValues"]["905"] == "cooling_comfort_setpoint_min"
     assert config["staticValues"]["903"] == "cooling_reduced_setpoint"
     assert config["staticValues_circuit2"]["1012"] == "temp_reduced_setpoint"
     assert config["staticValues_circuit2"]["1014"] == ("heating_protective_setpoint")
-    assert config["staticValues_circuit2"]["1016"] == "max_temp"
+    assert config["staticValues_circuit2"]["1016"] == "comfort_setpoint_max"
     assert config["staticValues_circuit2"]["1205"] == ("cooling_comfort_setpoint_min")
     assert config["staticValues_circuit2"]["1203"] == "cooling_reduced_setpoint"
     assert "908" not in config["staticValues"]

--- a/tests/test_include_parameter.py
+++ b/tests/test_include_parameter.py
@@ -407,9 +407,12 @@ async def test_static_values_with_include(monkeypatch: Any) -> None:
         request_mock: AsyncMock = AsyncMock(return_value=partial_response)
         monkeypatch.setattr(bsblan, "_request", request_mock)
 
-        static: StaticState = await bsblan.static_values(include=["min_temp"])
+        static: StaticState = await bsblan.static_values(
+            include=["temp_reduced_setpoint"]
+        )
 
-        assert static.min_temp is not None
+        assert static.temp_reduced_setpoint is not None
+        assert static.min_temp is None
         assert static.max_temp is None
 
 

--- a/tests/test_static_state.py
+++ b/tests/test_static_state.py
@@ -40,8 +40,9 @@ async def test_sensor(monkeypatch: Any) -> None:
 
         static: StaticState = await bsblan.static_values()
         assert isinstance(static, StaticState)
-        assert static.min_temp is not None
-        assert static.min_temp.value == 17.0
+        assert static.temp_reduced_setpoint is not None
+        assert static.temp_reduced_setpoint.value == 17.0
+        assert static.min_temp is None
         assert static.max_temp is not None
         assert static.max_temp.value == 23.0
         assert static.heating_protective_setpoint is not None

--- a/tests/test_static_state.py
+++ b/tests/test_static_state.py
@@ -43,8 +43,8 @@ async def test_sensor(monkeypatch: Any) -> None:
         assert static.temp_reduced_setpoint is not None
         assert static.temp_reduced_setpoint.value == 17.0
         assert static.min_temp is None
-        assert static.max_temp is not None
-        assert static.max_temp.value == 23.0
+        assert static.comfort_setpoint_max is not None
+        assert static.comfort_setpoint_max.value == 23.0
         assert static.heating_protective_setpoint is not None
         assert static.heating_protective_setpoint.value == 8.0
         assert static.cooling_comfort_setpoint_min is not None

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -153,7 +153,9 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
         client._api_validator = APIValidator(client._api_data)
 
         # Mock static_values to return data without min_temp
+        # Mock static_values without protective or pps min temp
         static_values_mock = AsyncMock()
+        static_values_mock.return_value.heating_protective_setpoint = None
         static_values_mock.return_value.min_temp = None
         static_values_mock.return_value.max_temp = AsyncMock()
         static_values_mock.return_value.max_temp.value = "30"
@@ -162,7 +164,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
         # This should log a warning
         await client._initialize_temperature_range()
 
-        # min_temp should remain None
+        # min should remain None when neither protective nor pps min is available
         temp_range = client._circuit_temp_ranges.get(1, {})
         assert temp_range.get("min") is None
 

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -157,6 +157,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
         static_values_mock = AsyncMock()
         static_values_mock.return_value.heating_protective_setpoint = None
         static_values_mock.return_value.min_temp = None
+        static_values_mock.return_value.comfort_setpoint_max = None
         static_values_mock.return_value.max_temp = AsyncMock()
         static_values_mock.return_value.max_temp.value = "30"
         monkeypatch.setattr(client, "static_values", static_values_mock)
@@ -190,6 +191,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
 
         # Mock static_values to return data without max_temp
         static_values_mock = AsyncMock()
+        static_values_mock.return_value.heating_protective_setpoint = None
         static_values_mock.return_value.min_temp = AsyncMock()
         static_values_mock.return_value.min_temp.value = "10"
         static_values_mock.return_value.comfort_setpoint_max = None

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -192,6 +192,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
         static_values_mock = AsyncMock()
         static_values_mock.return_value.min_temp = AsyncMock()
         static_values_mock.return_value.min_temp.value = "10"
+        static_values_mock.return_value.comfort_setpoint_max = None
         static_values_mock.return_value.max_temp = None
         monkeypatch.setattr(client, "static_values", static_values_mock)
 

--- a/tests/test_utility_additional.py
+++ b/tests/test_utility_additional.py
@@ -41,9 +41,9 @@ def fresh_api_validator() -> APIValidator:
             "710": "target_temperature",
         },
         "staticValues": {
-            "712": "min_temp",
+            "712": "temp_reduced_setpoint",
             "714": "heating_protective_setpoint",
-            "716": "max_temp",
+            "716": "comfort_setpoint_max",
         },
         "hot_water": {
             "8830": "dhw_actual_value_top_temperature",


### PR DESCRIPTION
This pull request refactors the handling of static temperature setpoints and their mapping throughout the codebase, clarifying the distinction between reduced (eco/night), comfort, and protective setpoints. The changes update internal models, API mappings, and tests to use more precise attribute names and logic for determining temperature bounds, improving maintainability and correctness.

**Refactoring of static temperature setpoint attributes:**

- Updated the `StaticState` model to add `temp_reduced_setpoint` and `comfort_setpoint_max` attributes, clarifying their meaning and use, while keeping `min_temp` and `max_temp` for legacy/PPS support.
- Changed all API parameter mappings and fixtures to use `temp_reduced_setpoint` (was `min_temp`) and `comfort_setpoint_max` (was `max_temp`) for both circuits, ensuring consistent naming throughout. [[1]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL43-R45) [[2]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL110-R112) [[3]](diffhunk://#diff-f752c115acbba00fb6eae679b3c1f20d148b2bec3cb98d31321d09076806700fL10-R12) [[4]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL131-R138) [[5]](diffhunk://#diff-385092e0abcee00fb9dc44d21071fd34a3e8baeac1bcda02ed0113c9ba8e1a45L44-R46)

**Temperature range calculation logic improvements:**

- Updated logic in `_fetch_temperature_range` to prefer `heating_protective_setpoint` as the lower bound and `comfort_setpoint_max` as the upper bound, falling back to `min_temp`/`max_temp` only for PPS circuits.

**Test updates for new attribute names and logic:**

- Refactored tests to assert on `temp_reduced_setpoint` and `comfort_setpoint_max` instead of `min_temp` and `max_temp`, and updated expected values to reflect the new lower bound logic (e.g., using the protective setpoint as min). [[1]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L228-R231) [[2]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L493-R493) [[3]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L529-R533) [[4]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L587-R587) [[5]](diffhunk://#diff-9901640b83f9e649356542790cf8cb5df264445a69d6557b67ffda3417a08d93L410-R415) [[6]](diffhunk://#diff-0fab8feab798885177aaaa67a34f68e3def85acaa70d10dcce557df1eae24f7cL43-R47)
- Enhanced tests to cover cases where neither protective nor PPS min is available, ensuring correct behavior when temperature bounds are missing. [[1]](diffhunk://#diff-4c2df41b90a609250317c411aacea720d54de5ad37f09a2a0a56b4cbc4d0829bR156-R158) [[2]](diffhunk://#diff-4c2df41b90a609250317c411aacea720d54de5ad37f09a2a0a56b4cbc4d0829bL165-R167) [[3]](diffhunk://#diff-4c2df41b90a609250317c411aacea720d54de5ad37f09a2a0a56b4cbc4d0829bR195)

**User-facing output updates:**

- Updated `print_static_state` to display the new setpoint names and pull the temperature unit from the correct attribute. [[1]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L203-R206) [[2]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L214-R218)