### PR TITLE
Fix thermostat min-temp regression and improve setpoint clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ asyncio.run(main())
 For more examples, including hot water control, multi-circuit support, and
 authentication setup, see the [Getting Started][docs-getting-started] guide.
 
+## Compatibility
+
+The client automatically detects the device's capabilities during
+`initialize()` and selects a matching configuration:
+
+- **Full support (`v3`)** — modern BSB-LAN firmware (3.x and newer, including
+  4.x and 5.x). All features are available: multiple heating circuits, hot
+  water control, schedules, sensors, and cooling setpoints.
+- **Basic support (`v2`)** — the legacy 2.x firmware branch. A reduced,
+  single-circuit configuration covering essential heating, hot water, and
+  sensor parameters.
+
+Detection prefers the documented BSB-LAN JSON-API version reported by the
+`/JV` endpoint, which is independent of the adapter firmware version. When a
+device does not expose `/JV` (very old firmware), the firmware version reported
+by `/JI` is used as a fallback. Firmware older than the 2.x branch is not
+supported.
+
+> Note: basic 2.x support is best-effort and may not cover every parameter your
+> heating system exposes.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -76,6 +76,10 @@ Data models for BSB-LAN API responses.
 
 ::: bsblan.Device
 
+### ApiVersion
+
+::: bsblan.ApiVersion
+
 ### Info
 
 ::: bsblan.Info

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,11 +85,14 @@ system exposes.
 
 ## Temperature bounds
 
-For heating comfort setpoint writes (`target_temperature`), `min_temp` maps to
-the reduced setpoint (`712` for circuit 1, `1012` for circuit 2). The protective
-setpoints (`714` and `1014`) are exposed separately and are not used as the
-comfort setpoint lower bound. The upper heating bound is `716` for circuit 1 and
-`1016` for circuit 2 when the device exposes those parameters.
+For heating comfort setpoint writes (`target_temperature`), the lower bound is
+the protective (frost) setpoint (`714` for circuit 1, `1014` for circuit 2),
+which allows setpoints down to the frost-protection temperature. The reduced
+setpoint (`712`/`1012`) is exposed as `min_temp` for reference and is used as a
+fallback lower bound only when the protective setpoint is unavailable (for
+example, on PPS devices). The upper heating bound is the comfort maximum (`716`
+for circuit 1 and `1016` for circuit 2) when the device exposes those
+parameters.
 
 ## Cooling setpoint support
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,6 +63,26 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Firmware compatibility
+
+On the first request the client lazily runs `initialize()`, which detects the
+device's capabilities and selects a matching configuration:
+
+- **Full support (`v3`)** — BSB-LAN firmware 3.x and newer (including 4.x and
+  5.x). All features are available, including multiple heating circuits, hot
+  water control, schedules, sensors, and cooling setpoints.
+- **Basic support (`v2`)** — the legacy 2.x firmware branch. A reduced,
+  single-circuit configuration covering essential heating, hot water, and
+  sensor parameters.
+
+Detection prefers the BSB-LAN JSON-API version reported by the `/JV` endpoint,
+which is independent of the adapter firmware version. When a device does not
+expose `/JV` (very old firmware), the firmware version from `/JI` is used as a
+fallback. Firmware older than the 2.x branch raises `BSBLANVersionError`.
+
+Basic 2.x support is best-effort and may not cover every parameter your heating
+system exposes.
+
 ## Temperature bounds
 
 For heating comfort setpoint writes (`target_temperature`), `min_temp` maps to

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@ Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) d
 - Control thermostat settings and hot water parameters
 - Detect optional cooling setpoints for heat/cool range controls
 - Fully typed with PEP 561 support
-- API v3 parameter support
+- API v3 parameter support, plus basic support for the legacy 2.x firmware
+- Automatic version detection via the BSB-LAN JSON-API (`/JV`)
 - Lazy loading with per-section validation
 
 ## Quick example

--- a/examples/control.py
+++ b/examples/control.py
@@ -171,17 +171,28 @@ def print_device_time(device_time: DeviceTime) -> None:
     print_attributes("Device Time", attributes)
 
 
-def print_device_info(device: Device, info: Info) -> None:
+def print_device_info(
+    device: Device,
+    info: Info,
+    api_version: str | None = None,
+    json_api_version: str | None = None,
+) -> None:
     """Print device and general information.
 
     Args:
         device (Device): The device information from the BSBLan device.
         info (Info): The general information from the BSBLan device.
+        api_version (str | None): The resolved API configuration version
+            (``"v2"`` or ``"v3"``).
+        json_api_version (str | None): The BSB-LAN JSON-API version reported by
+            the ``/JV`` endpoint, if available.
 
     """
     attributes = {
         "Device Name": device.name or "N/A",
         "Version": device.version or "N/A",
+        "API Version (config)": format_optional(api_version),
+        "JSON-API Version (/JV)": format_optional(json_api_version),
         "Device Identification": get_attribute(info.device_identification),
         "Bus Type": format_optional(device.bus),
         "Bus Writable Flag": format_optional(device.buswritable),
@@ -339,7 +350,12 @@ async def main() -> None:
         # Get and print device and general info, including bus metadata
         device: Device = bsblan.device_info or await bsblan.device()
         info: Info = await bsblan.info()
-        print_device_info(device, info)
+        print_device_info(
+            device,
+            info,
+            api_version=bsblan.api_version,
+            json_api_version=bsblan.json_api_version,
+        )
 
         # Get and print state
         state: State = await bsblan.state()

--- a/src/bsblan/__init__.py
+++ b/src/bsblan/__init__.py
@@ -8,8 +8,14 @@ from .constants import (
     HVACActionCategory,
     get_hvac_action_category,
 )
-from .exceptions import BSBLANAuthError, BSBLANConnectionError, BSBLANError
+from .exceptions import (
+    BSBLANAuthError,
+    BSBLANConnectionError,
+    BSBLANError,
+    BSBLANVersionError,
+)
 from .models import (
+    ApiVersion,
     DaySchedule,
     Device,
     DeviceTime,
@@ -34,10 +40,12 @@ __all__ = [
     "BSBLAN",
     "UNIT_DEVICE_CLASS_MAP",
     "UNIT_STATE_CLASS_MAP",
+    "ApiVersion",
     "BSBLANAuthError",
     "BSBLANConfig",
     "BSBLANConnectionError",
     "BSBLANError",
+    "BSBLANVersionError",
     "DHWSchedule",
     "DHWTimeSwitchPrograms",
     "DaySchedule",

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -866,7 +866,7 @@ class BSBLAN:
         if self._api_version is None:
             raise BSBLANError(ErrorMsg.API_VERSION)
         if self._api_version not in SUPPORTED_API_VERSIONS:
-            raise BSBLANVersionError(ErrorMsg.VERSION)
+            raise BSBLANVersionError(ErrorMsg.VERSION, version=self._api_version)
         source_config: APIConfig = (
             API_V2 if self._api_version == BASIC_API_VERSION else API_V3
         )

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -19,10 +19,17 @@ from packaging.version import InvalidVersion
 from yarl import URL
 
 from .constants import (
+    API_V2,
     API_V3,
+    BASIC_API_VERSION,
+    MIN_SUPPORTED_FIRMWARE,
+    MIN_SUPPORTED_JSON_API,
     PPS_HEATING_PARAMS,
     PPS_STATIC_VALUES_PARAMS,
     SUPPORTED_API_VERSION,
+    SUPPORTED_API_VERSIONS,
+    V3_FIRMWARE_MINIMUM,
+    V3_JSON_API_MINIMUM,
     APIConfig,
     CircuitConfig,
     ErrorMsg,
@@ -38,6 +45,7 @@ from .exceptions import (
     BSBLANVersionError,
 )
 from .models import (
+    ApiVersion,
     DaySchedule,
     Device,
     DeviceTime,
@@ -102,6 +110,7 @@ class BSBLAN:
     session: ClientSession | None = None
     _close_session: bool = False
     _firmware_version: str | None = None
+    _json_api_version: str | None = None
     _api_version: str | None = SUPPORTED_API_VERSION
     _api_data: APIConfig | None = None
     _device: Device | None = None
@@ -544,12 +553,53 @@ class BSBLAN:
             device = await self.device()
             self._firmware_version = device.version
             logger.debug("BSBLAN version: %s", self._firmware_version)
+            await self._fetch_json_api_version()
             self._set_api_version()
+
+    async def _fetch_json_api_version(self) -> None:
+        """Fetch the BSB-LAN JSON-API version from the /JV endpoint.
+
+        The JSON-API version (e.g. ``"2.0"``) is the documented,
+        firmware-independent compatibility signal. Older firmware may not
+        expose the /JV endpoint; in that case the value is left as ``None`` and
+        the firmware version is used as a fallback for selecting the API config.
+        """
+        if self._json_api_version is not None:
+            return
+        try:
+            response = await self._request(base_path="/JV")
+            api_version = ApiVersion.model_validate(response)
+        except (BSBLANError, ValueError, KeyError) as exc:
+            # /JV is unavailable or returned an unexpected payload; fall back to
+            # firmware-version based detection.
+            logger.debug("JSON-API version unavailable from /JV: %s", exc)
+            return
+        self._json_api_version = api_version.api_version
+        logger.debug("BSBLAN JSON-API version: %s", self._json_api_version)
 
     @property
     def device_info(self) -> Device | None:
         """Return cached device metadata from the last /JI response."""
         return self._device
+
+    @property
+    def api_version(self) -> str | None:
+        """Return the resolved API configuration version (``"v2"`` or ``"v3"``).
+
+        The value is populated during initialization. ``"v3"`` indicates full
+        support and ``"v2"`` the basic single-circuit configuration.
+        """
+        return self._api_version
+
+    @property
+    def json_api_version(self) -> str | None:
+        """Return the BSB-LAN JSON-API version reported by ``/JV``.
+
+        This is the firmware-independent JSON-API version (e.g. ``"2.0"``).
+        Returns ``None`` when the device does not expose the ``/JV`` endpoint,
+        in which case the firmware version is used to resolve ``api_version``.
+        """
+        return self._json_api_version
 
     @property
     def supports_time_sync(self) -> bool:
@@ -572,23 +622,70 @@ class BSBLAN:
             await self.device()
 
     def _set_api_version(self) -> None:
-        """Set the API version based on the firmware version.
+        """Set the API version used to select the configuration.
+
+        The BSB-LAN JSON-API version (from /JV) is the documented,
+        firmware-independent compatibility signal and is preferred when
+        available. When the device does not expose /JV (very old firmware), the
+        adapter firmware version (from /JI) is used as a fallback.
 
         Raises:
-            BSBLANError: If the firmware version is not set.
-            BSBLANVersionError: If the firmware version is not supported.
+            BSBLANError: If neither the JSON-API version nor the firmware
+                version is available.
+            BSBLANVersionError: If the reported version is not supported.
 
         """
+        if self._json_api_version is not None:
+            self._api_version = self._resolve_api_version(
+                self._json_api_version,
+                minimum=MIN_SUPPORTED_JSON_API,
+                v3_minimum=V3_JSON_API_MINIMUM,
+            )
+            return
+
         if not self._firmware_version:
             raise BSBLANError(ErrorMsg.FIRMWARE_VERSION)
 
+        self._api_version = self._resolve_api_version(
+            self._firmware_version,
+            minimum=MIN_SUPPORTED_FIRMWARE,
+            v3_minimum=V3_FIRMWARE_MINIMUM,
+        )
+
+    def _resolve_api_version(
+        self,
+        reported: str,
+        *,
+        minimum: str,
+        v3_minimum: str,
+    ) -> str:
+        """Map a reported version string to a supported API config version.
+
+        Args:
+            reported: The version string reported by the device.
+            minimum: The lowest supported version; anything below is rejected.
+            v3_minimum: The threshold at or above which the full "v3" config is
+                used; below it the basic "v2" config is used.
+
+        Returns:
+            ``"v2"`` for the basic single-circuit config or ``"v3"`` for the
+            full config.
+
+        Raises:
+            BSBLANVersionError: If the reported version cannot be parsed or is
+                below ``minimum``.
+
+        """
         try:
-            firmware_version = pkg_version.parse(self._firmware_version)
+            parsed = pkg_version.parse(reported)
         except InvalidVersion as exc:
-            raise BSBLANVersionError(ErrorMsg.VERSION) from exc
-        if firmware_version < pkg_version.parse("3.0.0"):
-            raise BSBLANVersionError(ErrorMsg.VERSION)
-        self._api_version = SUPPORTED_API_VERSION
+            raise BSBLANVersionError(ErrorMsg.VERSION, version=reported) from exc
+        if parsed < pkg_version.parse(minimum):
+            raise BSBLANVersionError(ErrorMsg.VERSION, version=reported)
+        if parsed < pkg_version.parse(v3_minimum):
+            # Legacy / basic capability: single-circuit support only.
+            return BASIC_API_VERSION
+        return SUPPORTED_API_VERSION
 
     async def _fetch_temperature_range(
         self,
@@ -768,9 +865,11 @@ class BSBLAN:
         """
         if self._api_version is None:
             raise BSBLANError(ErrorMsg.API_VERSION)
-        if self._api_version != SUPPORTED_API_VERSION:
+        if self._api_version not in SUPPORTED_API_VERSIONS:
             raise BSBLANVersionError(ErrorMsg.VERSION)
-        source_config: APIConfig = API_V3
+        source_config: APIConfig = (
+            API_V2 if self._api_version == BASIC_API_VERSION else API_V3
+        )
         return cast(
             "APIConfig",
             {

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -11,7 +11,34 @@ MAX_CIRCUIT: Final[int] = 2
 
 
 # API version
+# "v3" is the full configuration for BSB-LAN firmware >= 3.0.0.
+# "v2" is a reduced "basic" configuration for the legacy 2.x firmware branch:
+# a single heating circuit plus essential heating, hot water and sensor params.
 SUPPORTED_API_VERSION: Final[str] = "v3"
+BASIC_API_VERSION: Final[str] = "v2"
+SUPPORTED_API_VERSIONS: Final[tuple[str, ...]] = (
+    BASIC_API_VERSION,
+    SUPPORTED_API_VERSION,
+)
+
+# Firmware version thresholds (BSB-LAN adapter firmware, from /JI).
+# Firmware below MIN_SUPPORTED_FIRMWARE is rejected outright. Firmware in the
+# [MIN_SUPPORTED_FIRMWARE, V3_FIRMWARE_MINIMUM) range maps to the basic "v2"
+# config, and firmware >= V3_FIRMWARE_MINIMUM maps to the full "v3" config.
+# The firmware version is only used as a fallback when the JSON-API version
+# (from /JV) is not available (very old firmware that predates that endpoint).
+MIN_SUPPORTED_FIRMWARE: Final[str] = "2.0.0"
+V3_FIRMWARE_MINIMUM: Final[str] = "3.0.0"
+
+# JSON-API version thresholds (from /JV, distinct from adapter firmware).
+# The /JV endpoint reports the BSB-LAN JSON-API version (e.g. "2.0"), which is
+# the documented, firmware-independent compatibility signal. When available it
+# is the primary signal for selecting the API config: a JSON-API version below
+# MIN_SUPPORTED_JSON_API is rejected, the [MIN_SUPPORTED_JSON_API,
+# V3_JSON_API_MINIMUM) range maps to the basic "v2" config, and a version
+# >= V3_JSON_API_MINIMUM maps to the full "v3" config.
+MIN_SUPPORTED_JSON_API: Final[str] = "1.0"
+V3_JSON_API_MINIMUM: Final[str] = "2.0"
 
 
 class APIConfig(TypedDict):
@@ -114,6 +141,24 @@ BASE_STATIC_VALUES_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
     "1203": "cooling_reduced_setpoint",
 }
 
+# --- Basic "v2" parameters (legacy 2.x firmware) ---
+# A deliberately minimal, single-circuit set covering core heating control and
+# the min/max bounds needed for a thermostat. Cooling, boost and circuit 2 are
+# intentionally excluded because they are not reliably available on the legacy
+# firmware branch. Hot water, sensor and device params reuse the shared base
+# sets and are filtered per-section against what the device actually exposes.
+BASIC_HEATING_PARAMS: Final[dict[str, str]] = {
+    "700": "hvac_mode",
+    "710": "target_temperature",
+    "8000": "hvac_action",
+    "8740": "current_temperature",
+}
+
+BASIC_STATIC_VALUES_PARAMS: Final[dict[str, str]] = {
+    "714": "heating_protective_setpoint",
+    "716": "comfort_setpoint_max",
+}
+
 # PPS bus supports one room-unit style climate circuit. These parameters are
 # exposed by BSB-LAN in the 15000+ range and mirror the circuit 1 climate model.
 PPS_HEATING_PARAMS: Final[dict[str, str]] = {
@@ -165,21 +210,37 @@ class CircuitConfig:
 
 
 def build_api_config(version: str = SUPPORTED_API_VERSION) -> APIConfig:
-    """Build the supported v3 API configuration.
+    """Build the API configuration for a supported version.
 
     Args:
-        version: The API version to build. Only ``"v3"`` is supported.
+        version: The API version to build. ``"v3"`` returns the full
+            configuration; ``"v2"`` returns the reduced single-circuit basic
+            configuration for legacy 2.x firmware.
 
     Returns:
         APIConfig: The complete API configuration.
 
     Raises:
-        ValueError: If a version other than ``"v3"`` is requested.
+        ValueError: If a version other than ``"v2"`` or ``"v3"`` is requested.
 
     """
-    if version != SUPPORTED_API_VERSION:
-        msg = f"Only API version {SUPPORTED_API_VERSION} is supported"
+    if version not in SUPPORTED_API_VERSIONS:
+        supported = ", ".join(SUPPORTED_API_VERSIONS)
+        msg = f"Only API versions {supported} are supported"
         raise ValueError(msg)
+
+    if version == BASIC_API_VERSION:
+        # Basic single-circuit config for legacy 2.x firmware. Circuit 2 and
+        # cooling are intentionally empty/omitted.
+        return {
+            "heating": BASIC_HEATING_PARAMS.copy(),
+            "staticValues": BASIC_STATIC_VALUES_PARAMS.copy(),
+            "device": BASE_DEVICE_PARAMS.copy(),
+            "sensor": BASE_SENSOR_PARAMS.copy(),
+            "hot_water": BASE_HOT_WATER_PARAMS.copy(),
+            "heating_circuit2": {},
+            "staticValues_circuit2": {},
+        }
 
     config: APIConfig = {
         "heating": BASE_HEATING_PARAMS.copy(),
@@ -194,7 +255,8 @@ def build_api_config(version: str = SUPPORTED_API_VERSION) -> APIConfig:
     return config
 
 
-# Pre-built API configuration
+# Pre-built API configurations
+API_V2: Final[APIConfig] = build_api_config(BASIC_API_VERSION)
 API_V3: Final[APIConfig] = build_api_config()
 
 

--- a/src/bsblan/exceptions.py
+++ b/src/bsblan/exceptions.py
@@ -41,6 +41,22 @@ class BSBLANVersionError(BSBLANError):
 
     message: str = "The BSBLAN device has an unsupported version."
 
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        version: str | None = None,
+    ) -> None:
+        """Initialize a new instance of the BSBLANVersionError class.
+
+        Args:
+            message: Optional custom error message.
+            version: The unsupported firmware version, if known.
+
+        """
+        self.version = version
+        super().__init__(message)
+
 
 class BSBLANInvalidParameterError(BSBLANError):
     """Raised when an invalid parameter is provided."""

--- a/src/bsblan/exceptions.py
+++ b/src/bsblan/exceptions.py
@@ -40,6 +40,7 @@ class BSBLANVersionError(BSBLANError):
     """Raised when the BSBLAN device has an unsupported version."""
 
     message: str = "The BSBLAN device has an unsupported version."
+    version: str | None = None
 
     def __init__(
         self,

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -644,6 +644,17 @@ class Device(BaseModel):
         return not self.is_pps_bus
 
 
+class ApiVersion(BaseModel):
+    """Object holding the BSB-LAN JSON-API version reported by /JV.
+
+    This is the JSON-API version (e.g. ``"2.0"``), which is distinct from the
+    adapter firmware version reported by /JI. It is the documented,
+    firmware-independent signal used to select a compatible API configuration.
+    """
+
+    api_version: str
+
+
 class Info(BaseModel):
     """Object holding the heatingSystem info.
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -497,10 +497,10 @@ async def test_circuit2_temp_range_initialization(
 
 
 @pytest.mark.asyncio
-async def test_circuit1_temp_range_uses_reduced_lower_bound(
+async def test_circuit1_temp_range_uses_protective_lower_bound(
     monkeypatch: Any,
 ) -> None:
-    """Test that HC1 temp range uses the reduced setpoint lower bound."""
+    """Test that HC1 temp range uses the protective setpoint lower bound."""
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
@@ -526,6 +526,8 @@ async def test_circuit1_temp_range_uses_reduced_lower_bound(
         await bsblan._initialize_temperature_range(circuit=1)
 
         assert 1 in bsblan._circuit_temp_initialized
+        # Lower bound is the protective/frost setpoint (714 = 8.0), not the
+        # reduced setpoint (712 = 17.0).
         assert bsblan._circuit_temp_ranges[1]["min"] == 8.0
         assert bsblan._circuit_temp_ranges[1]["max"] == 23.0
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,6 +5,7 @@ import pytest
 import bsblan
 import bsblan.constants
 from bsblan.constants import (
+    API_V2,
     API_V3,
     BASE_HOT_WATER_PARAMS,
     HeatingCircuitStatus,
@@ -51,10 +52,38 @@ def test_build_api_config_defaults_to_v3() -> None:
     assert build_api_config("v3") == config
 
 
+def test_build_api_config_v2_is_basic_single_circuit() -> None:
+    """Test the basic v2 config is single-circuit and excludes cooling/boost."""
+    config = build_api_config("v2")
+
+    # Core heating control is present.
+    assert config["heating"] == {
+        "700": "hvac_mode",
+        "710": "target_temperature",
+        "8000": "hvac_action",
+        "8740": "current_temperature",
+    }
+    # Min/max bounds for the thermostat are present.
+    assert config["staticValues"] == {
+        "714": "heating_protective_setpoint",
+        "716": "comfort_setpoint_max",
+    }
+    # Cooling and boost params are excluded.
+    for excluded in ("900", "902", "770", "905", "903", "712"):
+        assert excluded not in config["heating"]
+        assert excluded not in config["staticValues"]
+    # Only a single circuit is supported.
+    assert config["heating_circuit2"] == {}
+    assert config["staticValues_circuit2"] == {}
+    # Hot water and sensors reuse the shared base sets.
+    assert config["hot_water"] == BASE_HOT_WATER_PARAMS
+    assert config == API_V2
+
+
 @pytest.mark.parametrize("version", ["v1", "v5"])
 def test_build_api_config_rejects_unsupported_versions(version: str) -> None:
-    """Test that only API v3 can be built."""
-    with pytest.raises(ValueError, match="Only API version v3 is supported"):
+    """Test that only API v2 and v3 can be built."""
+    with pytest.raises(ValueError, match="Only API versions v2, v3 are supported"):
         build_api_config(version)
 
 

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -159,7 +159,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
         static_values_mock.return_value.min_temp = None
         static_values_mock.return_value.comfort_setpoint_max = None
         static_values_mock.return_value.max_temp = AsyncMock()
-        static_values_mock.return_value.max_temp.value = "30"
+        static_values_mock.return_value.max_temp.value = 30.0
         monkeypatch.setattr(client, "static_values", static_values_mock)
 
         # This should log a warning
@@ -193,7 +193,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
         static_values_mock = AsyncMock()
         static_values_mock.return_value.heating_protective_setpoint = None
         static_values_mock.return_value.min_temp = AsyncMock()
-        static_values_mock.return_value.min_temp.value = "10"
+        static_values_mock.return_value.min_temp.value = 10.0
         static_values_mock.return_value.comfort_setpoint_max = None
         static_values_mock.return_value.max_temp = None
         monkeypatch.setattr(client, "static_values", static_values_mock)

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -29,11 +29,23 @@ async def test_set_api_version_unsupported() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Set firmware version to an unsupported value (between 1.2.0 and 3.0.0)
-    bsblan._firmware_version = "2.0.0"
+    # Set firmware version below the supported floor (< 2.0.0)
+    bsblan._firmware_version = "1.9.0"
 
     with pytest.raises(BSBLANVersionError):
         bsblan._set_api_version()
+
+
+@pytest.mark.asyncio
+async def test_set_api_version_v2_basic() -> None:
+    """Test legacy 2.x firmware maps to the basic v2 config."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._firmware_version = "2.2.3"
+    bsblan._set_api_version()
+
+    assert bsblan._api_version == "v2"
 
 
 @pytest.mark.asyncio
@@ -89,6 +101,7 @@ async def test_fetch_firmware_version() -> None:
     # Mock device method to return our test device
     with (
         patch.object(bsblan, "device", AsyncMock(return_value=device)),
+        patch.object(bsblan, "_fetch_json_api_version", AsyncMock()),
         patch.object(bsblan, "_set_api_version"),
     ):
         await bsblan._fetch_firmware_version()
@@ -208,12 +221,209 @@ async def test_set_api_version_v5_edge_cases() -> None:
 
 @pytest.mark.asyncio
 async def test_unsupported_version_still_fails() -> None:
-    """Test that unsupported versions before 3.0.0 still fail."""
+    """Test that firmware below the supported floor (< 2.0.0) still fails."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Test that version 2.0.0 still fails
-    bsblan._firmware_version = "2.0.0"
+    # Test that version 1.9.9 still fails
+    bsblan._firmware_version = "1.9.9"
 
     with pytest.raises(BSBLANVersionError):
         bsblan._set_api_version()
+
+
+@pytest.mark.asyncio
+async def test_legacy_2x_maps_to_basic_v2() -> None:
+    """Test that legacy 2.x firmware maps to the basic v2 config."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    # 2.0.0 is the lower bound of basic support
+    bsblan._firmware_version = "2.0.0"
+    bsblan._set_api_version()
+    assert bsblan._api_version == "v2"
+
+    # 2.9.9 still maps to basic v2 (below the 3.0.0 v3 threshold)
+    bsblan._firmware_version = "2.9.9"
+    bsblan._set_api_version()
+    assert bsblan._api_version == "v2"
+
+
+@pytest.mark.asyncio
+async def test_json_api_version_v3() -> None:
+    """Test JSON-API version >= 2.0 maps to the full v3 config."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._json_api_version = "2.0"
+    bsblan._set_api_version()
+
+    assert bsblan._api_version == "v3"
+
+
+@pytest.mark.asyncio
+async def test_json_api_version_basic_v2() -> None:
+    """Test JSON-API version in [1.0, 2.0) maps to the basic v2 config."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._json_api_version = "1.5"
+    bsblan._set_api_version()
+
+    assert bsblan._api_version == "v2"
+
+
+@pytest.mark.asyncio
+async def test_json_api_version_unsupported() -> None:
+    """Test JSON-API version below the supported floor raises."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._json_api_version = "0.9"
+
+    with pytest.raises(BSBLANVersionError):
+        bsblan._set_api_version()
+
+
+@pytest.mark.asyncio
+async def test_json_api_version_invalid_string() -> None:
+    """Test a non-PEP440 JSON-API version raises BSBLANVersionError."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._json_api_version = "not-a-version"
+
+    with pytest.raises(BSBLANVersionError):
+        bsblan._set_api_version()
+
+
+@pytest.mark.asyncio
+async def test_json_api_version_takes_precedence_over_firmware() -> None:
+    """Test the JSON-API version is preferred over the firmware version."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    # Firmware would map to v2, but a modern JSON-API version wins.
+    bsblan._firmware_version = "2.2.3"
+    bsblan._json_api_version = "2.0"
+    bsblan._set_api_version()
+
+    assert bsblan._api_version == "v3"
+
+
+@pytest.mark.asyncio
+async def test_api_version_property() -> None:
+    """Test the public api_version property reflects the resolved version."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._json_api_version = "2.0"
+    bsblan._set_api_version()
+
+    assert bsblan.api_version == "v3"
+
+
+@pytest.mark.asyncio
+async def test_json_api_version_property() -> None:
+    """Test the public json_api_version property exposes the /JV version."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    # Defaults to None until /JV is fetched.
+    assert bsblan.json_api_version is None
+
+    bsblan._json_api_version = "2.0"
+    assert bsblan.json_api_version == "2.0"
+
+
+@pytest.mark.asyncio
+async def test_version_error_exposes_version() -> None:
+    """Test BSBLANVersionError stores the unsupported version on the exception."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._firmware_version = "1.9.0"
+
+    with pytest.raises(BSBLANVersionError) as exc_info:
+        bsblan._set_api_version()
+
+    assert exc_info.value.version == "1.9.0"
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_api_version_success() -> None:
+    """Test fetching the JSON-API version from the /JV endpoint."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    with patch.object(
+        bsblan, "_request", AsyncMock(return_value={"api_version": "2.0"})
+    ) as mock_request:
+        await bsblan._fetch_json_api_version()
+
+    assert bsblan._json_api_version == "2.0"
+    mock_request.assert_awaited_once_with(base_path="/JV")
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_api_version_falls_back_on_error() -> None:
+    """Test a missing /JV endpoint leaves the JSON-API version unset."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    with patch.object(bsblan, "_request", AsyncMock(side_effect=BSBLANError("404"))):
+        await bsblan._fetch_json_api_version()
+
+    assert bsblan._json_api_version is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_api_version_falls_back_on_malformed_payload() -> None:
+    """Test a malformed /JV payload leaves the JSON-API version unset."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    with patch.object(
+        bsblan, "_request", AsyncMock(return_value={"unexpected": "data"})
+    ):
+        await bsblan._fetch_json_api_version()
+
+    assert bsblan._json_api_version is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_api_version_cached() -> None:
+    """Test the JSON-API version is not re-fetched when already known."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    bsblan._json_api_version = "2.0"
+
+    with patch.object(bsblan, "_request", AsyncMock()) as mock_request:
+        await bsblan._fetch_json_api_version()
+
+    mock_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_firmware_version_queries_json_api() -> None:
+    """Test firmware fetch also fetches the JSON-API version."""
+    config = BSBLANConfig(host="example.com")
+    bsblan = BSBLAN(config)
+
+    device = Device(
+        name="Test Device", version="2.2.3", MAC="00:11:22:33:44:55", uptime=1000
+    )
+
+    with (
+        patch.object(bsblan, "device", AsyncMock(return_value=device)),
+        patch.object(
+            bsblan, "_request", AsyncMock(return_value={"api_version": "2.0"})
+        ),
+    ):
+        await bsblan._fetch_firmware_version()
+
+    assert bsblan._firmware_version == "2.2.3"
+    assert bsblan._json_api_version == "2.0"
+    # JSON-API version wins over the legacy firmware mapping.
+    assert bsblan._api_version == "v3"


### PR DESCRIPTION
This pull request adds robust compatibility detection for BSB-LAN firmware and JSON-API versions, enabling both full support for modern devices and best-effort support for legacy 2.x firmware. The client now automatically detects device capabilities during initialization and selects the appropriate configuration. The changes also improve version reporting, temperature bound handling, and documentation to reflect these enhancements.

**Compatibility and Version Detection:**

- Automatic detection of device capabilities during `initialize()`, preferring the BSB-LAN JSON-API version (`/JV`) and falling back to firmware version (`/JI`) if needed; legacy 2.x firmware now receives basic support, while 3.x and above get full support. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R556-R603) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L575-R688) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L742-R872) [[4]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdR14-R41)
- Added `api_version` and `json_api_version` properties to the `BSBLAN` client for reporting the resolved API configuration and detected JSON-API version, respectively.
- Introduced new constants and logic for version thresholds and configuration selection in `constants.py`.

**API and Model Updates:**

- Added the `ApiVersion` model and exported it in the public API. [[1]](diffhunk://#diff-5b2498f42713c9e42aee64702da82bfd7c399f8ef66ec34779baff03026bead2L11-R18) [[2]](diffhunk://#diff-5b2498f42713c9e42aee64702da82bfd7c399f8ef66ec34779baff03026bead2R43-R48) [[3]](diffhunk://#diff-67edb934bfe37fbd614c06ff6b9d607332fb675e88e67a4736910c49b6ad58fcR79-R82)

**Temperature Bound Improvements:**

- Refined temperature bound detection: now prefers `heating_protective_setpoint` and `comfort_setpoint_max` for standard circuits, with fallbacks for PPS circuits, and skips inactive sources.
- Updated static state reporting and example output to reflect the new temperature attribute priorities. [[1]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692R206-R221) [[2]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L203-R233) [[3]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L214-R245) [[4]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL43-R72)

**Documentation and Example Enhancements:**

- Expanded documentation in `README.md`, `docs/getting-started.md`, and `docs/index.md` to describe compatibility detection, supported firmware, and JSON-API versioning. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-R74) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R66-R85) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L12-R13)
- Improved example scripts to display detected API and JSON-API versions. [[1]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L174-R195) [[2]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L322-R358)