### PR TITLE
Upgrade codecov-action to v7.0.0 for GPG key verification fix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,14 +84,14 @@ jobs:
           uv run python -m coverage xml -i
       - name: 🚀 Upload coverage report
         if: env.HAS_CODECOV_TOKEN == 'true'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: 🚀 Upload coverage report (tokenless)
         if: env.HAS_CODECOV_TOKEN != 'true' && github.event_name == 'pull_request'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: false
           files: coverage.xml


### PR DESCRIPTION
This pull request updates the Codecov GitHub Action used in the test workflow to a newer major version. This ensures that the workflow benefits from the latest features and fixes provided by Codecov.

CI workflow maintenance:

* Updated the `codecov/codecov-action` in `.github/workflows/tests.yaml` from version `v6.0.1` to `v7.0.0` for both token and tokenless coverage report uploads.