### PR TITLE
Refactor request helpers and deduplicate validation logic

### DIFF
--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -1120,8 +1120,9 @@ class BSBLAN:
             return params
         if not include:
             raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
+        include_set = set(include)
         filtered = {
-            param_id: name for param_id, name in params.items() if name in include
+            param_id: name for param_id, name in params.items() if name in include_set
         }
         if not filtered:
             raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -1323,12 +1323,9 @@ class BSBLAN:
         await self._ensure_device_metadata()
         self._validate_time_sync_supported()
         self._validate_time_format(time_value)
-        state: dict[str, object] = {
-            "Parameter": "0",
-            "Value": time_value,
-            "Type": "1",
-        }
-        response = await self._request(base_path="/JS", data=state)
+        response = await self._request(
+            base_path="/JS", data=self._set_payload("0", time_value)
+        )
         logger.debug("Response for setting time: %s", response)
 
     async def thermostat(
@@ -1407,11 +1404,7 @@ class BSBLAN:
                 circuit,
             )
             state.update(
-                {
-                    "Parameter": param_ids["target_temperature"],
-                    "Value": target_temperature,
-                    "Type": "1",
-                },
+                self._set_payload(param_ids["target_temperature"], target_temperature),
             )
         if target_temperature_high is not None:
             param_id = param_ids.get("target_temperature_high")
@@ -1423,11 +1416,7 @@ class BSBLAN:
                 circuit,
             )
             state.update(
-                {
-                    "Parameter": param_id,
-                    "Value": str(target_temperature_high),
-                    "Type": "1",
-                },
+                self._set_payload(param_id, str(target_temperature_high)),
             )
         if hvac_mode is not None:
             self._validate_hvac_mode(hvac_mode)
@@ -1435,11 +1424,7 @@ class BSBLAN:
             if self._uses_pps_bus:
                 hvac_value = Validation.PPS_HVAC_MODE_TO_BSBLAN[hvac_mode]
             state.update(
-                {
-                    "Parameter": param_ids["hvac_mode"],
-                    "Value": hvac_value,
-                    "Type": "1",
-                },
+                self._set_payload(param_ids["hvac_mode"], hvac_value),
             )
         return state
 
@@ -1544,6 +1529,22 @@ class BSBLAN:
             validate_time_format(time_value, Validation.MIN_YEAR, Validation.MAX_YEAR)
         except ValueError as err:
             raise BSBLANInvalidParameterError(str(err)) from err
+
+    def _set_payload(
+        self, parameter: str, value: str, type_: str = "1"
+    ) -> dict[str, Any]:
+        """Build a BSB-LAN ``/JS`` set-parameter payload.
+
+        Args:
+            parameter (str): The BSB-LAN parameter ID to set.
+            value (str): The value to write for the parameter.
+            type_ (str): The BSB-LAN set type. Defaults to ``"1"``.
+
+        Returns:
+            dict[str, Any]: The payload for a ``/JS`` set request.
+
+        """
+        return {"Parameter": parameter, "Value": value, "Type": type_}
 
     async def _set_device_state(self, state: dict[str, Any]) -> None:
         """Set device state via BSB-LAN API.
@@ -1737,17 +1738,7 @@ class BSBLAN:
         self._validate_circuit(circuit)
         time_program_params = HeatingScheduleParams.TIME_PROGRAMS[circuit]
 
-        filtered_params = time_program_params
-        if include is not None:
-            if not include:
-                raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
-            filtered_params = {
-                param_id: name
-                for param_id, name in time_program_params.items()
-                if name in include
-            }
-            if not filtered_params:
-                raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)
+        filtered_params = self._apply_include_filter(time_program_params, include)
 
         params = self._extract_params_summary(filtered_params)
         data = await self._request(params={"Parameter": params["string_par"]})
@@ -1794,12 +1785,9 @@ class BSBLAN:
         for day_name, param_id in day_param_map.items():
             day_schedule: DaySchedule | None = getattr(schedule, day_name)
             if day_schedule is not None:
-                state = {
-                    "Parameter": param_id,
-                    "Value": day_schedule.to_bsblan_format(),
-                    "Type": "1",
-                }
-                await self._set_device_state(state)
+                await self._set_device_state(
+                    self._set_payload(param_id, day_schedule.to_bsblan_format()),
+                )
 
     async def set_hot_water(self, params: SetHotWaterParam) -> None:
         """Change the state of the hot water system through BSB-Lan.
@@ -1895,12 +1883,9 @@ class BSBLAN:
         for day_name, param_id in day_param_map.items():
             day_schedule: DaySchedule | None = getattr(schedule, day_name)
             if day_schedule is not None:
-                state = {
-                    "Parameter": param_id,
-                    "Value": day_schedule.to_bsblan_format(),
-                    "Type": "1",
-                }
-                await self._set_device_state(state)
+                await self._set_device_state(
+                    self._set_payload(param_id, day_schedule.to_bsblan_format()),
+                )
 
     def _prepare_hot_water_state(
         self,
@@ -1924,14 +1909,14 @@ class BSBLAN:
         for param_id, attr_name in HotWaterParams.SETTABLE.items():
             value = getattr(params, attr_name)
             if value is not None:
-                state.update({"Parameter": param_id, "Value": str(value), "Type": "1"})
+                state.update(self._set_payload(param_id, str(value)))
 
         # Process time programs if provided using constants
         if params.dhw_time_programs:
             for param_id, attr_name in HotWaterParams.TIME_PROGRAMS.items():
                 value = getattr(params.dhw_time_programs, attr_name)
                 if value is not None:
-                    state.update({"Parameter": param_id, "Value": value, "Type": "1"})
+                    state.update(self._set_payload(param_id, value))
 
         if not state:
             raise BSBLANError(ErrorMsg.NO_STATE)

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -1434,29 +1434,61 @@ class BSBLAN:
             return {"target_temperature": "15004", "hvac_mode": "15000"}
         return CircuitConfig.THERMOSTAT_PARAMS[circuit]
 
+    async def _validate_temperature_in_range(
+        self,
+        value: str | float,
+        circuit: int,
+        *,
+        min_key: str,
+        max_key: str,
+    ) -> None:
+        """Validate a temperature value against a circuit's configured bounds.
+
+        Lazy-loads the circuit temperature range when needed. If the device
+        does not expose the relevant bounds, only the float conversion is
+        validated.
+
+        Args:
+            value (str | float): The temperature value to validate.
+            circuit (int): The heating circuit number (1 or 2).
+            min_key (str): Range key holding the lower bound.
+            max_key (str): Range key holding the upper bound.
+
+        Raises:
+            BSBLANInvalidParameterError: If the value is not a valid float or
+                falls outside the configured bounds.
+
+        """
+        try:
+            temp = float(value)
+        except ValueError as err:
+            raise BSBLANInvalidParameterError(str(value)) from err
+
+        if circuit not in self._circuit_temp_initialized:
+            await self._initialize_temperature_range(circuit)
+
+        temp_range = self._circuit_temp_ranges.get(circuit, {})
+        min_temp = temp_range.get(min_key)
+        max_temp = temp_range.get(max_key)
+
+        if min_temp is None or max_temp is None:
+            return
+
+        if not (min_temp <= temp <= max_temp):
+            raise BSBLANInvalidParameterError(str(value))
+
     async def _validate_target_temperature_high(
         self,
         target_temperature_high: str | float,
         circuit: int = 1,
     ) -> None:
         """Validate the cooling target temperature value."""
-        try:
-            temp = float(target_temperature_high)
-        except ValueError as err:
-            raise BSBLANInvalidParameterError(str(target_temperature_high)) from err
-
-        if circuit not in self._circuit_temp_initialized:
-            await self._initialize_temperature_range(circuit)
-
-        temp_range = self._circuit_temp_ranges.get(circuit, {})
-        min_temp = temp_range.get("cooling_min")
-        max_temp = temp_range.get("cooling_max")
-
-        if min_temp is None or max_temp is None:
-            return
-
-        if not (min_temp <= temp <= max_temp):
-            raise BSBLANInvalidParameterError(str(target_temperature_high))
+        await self._validate_temperature_in_range(
+            target_temperature_high,
+            circuit,
+            min_key="cooling_min",
+            max_key="cooling_max",
+        )
 
     async def _validate_target_temperature(
         self,
@@ -1477,26 +1509,12 @@ class BSBLAN:
             BSBLANInvalidParameterError: If the target temperature is invalid.
 
         """
-        # Validate it's a valid float first
-        try:
-            temp = float(target_temperature)
-        except ValueError as err:
-            raise BSBLANInvalidParameterError(target_temperature) from err
-
-        # Try to load temperature range for bounds checking
-        if circuit not in self._circuit_temp_initialized:
-            await self._initialize_temperature_range(circuit)
-
-        temp_range = self._circuit_temp_ranges.get(circuit, {})
-        min_temp = temp_range.get("min")
-        max_temp = temp_range.get("max")
-
-        # Skip range validation if device doesn't provide min/max
-        if min_temp is None or max_temp is None:
-            return
-
-        if not (min_temp <= temp <= max_temp):
-            raise BSBLANInvalidParameterError(target_temperature)
+        await self._validate_temperature_in_range(
+            target_temperature,
+            circuit,
+            min_key="min",
+            max_key="max",
+        )
 
     def _validate_hvac_mode(self, hvac_mode: int) -> None:
         """Validate the HVAC mode.

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Awaitable, Callable, Mapping
 
 import aiohttp
 import backoff
@@ -259,6 +259,40 @@ class BSBLAN:
         self._api_data["heating_circuit2"] = {}
         self._api_data["staticValues_circuit2"] = {}
 
+    async def _run_once_locked(
+        self,
+        key: str,
+        locks: dict[str, asyncio.Lock],
+        is_done: Callable[[], bool],
+        body: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Run an idempotent async operation at most once per key.
+
+        Implements double-checked locking: a fast path when the work is already
+        done, a per-key lock to serialize concurrent first-time callers, and a
+        re-check after acquiring the lock so only one caller runs ``body``.
+
+        Args:
+            key (str): Identifier for the one-time operation.
+            locks (dict[str, asyncio.Lock]): Registry of per-key locks, created
+                on demand.
+            is_done (Callable[[], bool]): Predicate returning True when the work
+                is already complete.
+            body (Callable[[], Awaitable[None]]): Coroutine factory executed once
+                while holding the lock.
+
+        """
+        if is_done():
+            return
+
+        if key not in locks:
+            locks[key] = asyncio.Lock()
+
+        async with locks[key]:
+            if is_done():
+                return
+            await body()
+
     async def _ensure_section_validated(
         self, section: SectionLiteral, include: list[str] | None = None
     ) -> None:
@@ -279,19 +313,7 @@ class BSBLAN:
         if not self._api_validator:
             raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
 
-        # Fast path: skip if already validated (no lock needed)
-        if self._api_validator.is_section_validated(section):
-            return
-
-        # Get or create lock for this section
-        if section not in self._section_locks:
-            self._section_locks[section] = asyncio.Lock()
-
-        async with self._section_locks[section]:
-            # Double-check after acquiring lock (another task may have validated)
-            if self._api_validator.is_section_validated(section):
-                return
-
+        async def _validate() -> None:
             logger.debug("Lazy loading section: %s", section)
             response_data = await self._validate_api_section(section, include)
 
@@ -299,6 +321,13 @@ class BSBLAN:
                 section, include, response_data
             ):
                 self._extract_temperature_unit_from_response(response_data)
+
+        await self._run_once_locked(
+            section,
+            self._section_locks,
+            lambda: self._api_validator.is_section_validated(section),
+            _validate,
+        )
 
     def _should_extract_temperature_unit(
         self,
@@ -337,24 +366,13 @@ class BSBLAN:
                 If provided, only these parameters will be validated.
 
         """
-        # Fast path: skip if already validated (no lock needed)
-        if group_name in self._validated_hot_water_groups:
-            return
 
-        if not self._api_validator:
-            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
+        async def _validate() -> None:
+            if not self._api_validator:
+                raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
 
-        if not self._api_data:
-            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
-
-        # Get or create lock for this group
-        if group_name not in self._hot_water_group_locks:
-            self._hot_water_group_locks[group_name] = asyncio.Lock()
-
-        async with self._hot_water_group_locks[group_name]:
-            # Double-check after acquiring lock (another task may have validated)
-            if group_name in self._validated_hot_water_groups:
-                return
+            if not self._api_data:
+                raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
 
             logger.debug("Lazy loading hot water group: %s", group_name)
 
@@ -422,6 +440,13 @@ class BSBLAN:
                 len(group_params),
                 len(params_to_remove),
             )
+
+        await self._run_once_locked(
+            group_name,
+            self._hot_water_group_locks,
+            lambda: group_name in self._validated_hot_water_groups,
+            _validate,
+        )
 
     async def _validate_api_section(
         self, section: SectionLiteral, include: list[str] | None = None

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -1073,6 +1073,50 @@ class BSBLAN:
         string_params = ",".join(map(str, params))
         return {"string_par": string_params, "list": list(params.values())}
 
+    def _apply_include_filter(
+        self, params: dict[str, str], include: list[str] | None
+    ) -> dict[str, str]:
+        """Filter a parameter map down to the requested parameter names.
+
+        Args:
+            params (dict[str, str]): Mapping of parameter ID to parameter name.
+            include (list[str] | None): Parameter names to keep. If None, the
+                mapping is returned unchanged.
+
+        Returns:
+            dict[str, str]: The filtered mapping (unchanged when include is None).
+
+        Raises:
+            BSBLANError: If include is an empty list, or if none of the requested
+                names match the available parameters.
+
+        """
+        if include is None:
+            return params
+        if not include:
+            raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
+        filtered = {
+            param_id: name for param_id, name in params.items() if name in include
+        }
+        if not filtered:
+            raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)
+        return filtered
+
+    async def _request_named_params(self, params: dict[str, str]) -> dict[str, Any]:
+        """Request parameters and key the response by parameter name.
+
+        Args:
+            params (dict[str, str]): Mapping of parameter ID to parameter name.
+
+        Returns:
+            dict[str, Any]: The device response re-keyed from parameter ID to
+                parameter name, positionally matching the request order.
+
+        """
+        summary = self._extract_params_summary(params)
+        data = await self._request(params={"Parameter": summary["string_par"]})
+        return dict(zip(summary["list"], list(data.values()), strict=True))
+
     async def _fetch_section_data(
         self,
         section: SectionLiteral,
@@ -1109,21 +1153,10 @@ class BSBLAN:
             msg = ErrorMsg.EMPTY_SECTION_PARAMS.format(section)
             raise BSBLANError(msg)
 
-        # Filter parameters if include list is specified
-        if include is not None:
-            if not include:
-                raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
-            section_params = {
-                param_id: name
-                for param_id, name in section_params.items()
-                if name in include
-            }
-            if not section_params:
-                raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)
+        # Filter to requested parameter names (if an include list was given)
+        section_params = self._apply_include_filter(section_params, include)
 
-        params = self._extract_params_summary(section_params)
-        data = await self._request(params={"Parameter": params["string_par"]})
-        data = dict(zip(params["list"], list(data.values()), strict=True))
+        data = await self._request_named_params(section_params)
         if section == "heating" and self._uses_pps_bus:
             self._normalize_pps_state_data(data)
         return model_class.model_validate(data)
@@ -1565,23 +1598,12 @@ class BSBLAN:
         }
 
         # Apply include filter if specified
-        if include is not None:
-            if not include:
-                raise BSBLANError(ErrorMsg.EMPTY_INCLUDE_LIST)
-            filtered_params = {
-                param_id: name
-                for param_id, name in filtered_params.items()
-                if name in include
-            }
-            if not filtered_params:
-                raise BSBLANError(ErrorMsg.INVALID_INCLUDE_PARAMS)
+        filtered_params = self._apply_include_filter(filtered_params, include)
 
         if not filtered_params:
             raise BSBLANError(error_msg)
 
-        params = self._extract_params_summary(filtered_params)
-        data = await self._request(params={"Parameter": params["string_par"]})
-        data = dict(zip(params["list"], list(data.values()), strict=True))
+        data = await self._request_named_params(filtered_params)
         return model_class.model_validate(data)
 
     async def hot_water_state(self, include: list[str] | None = None) -> HotWaterState:


### PR DESCRIPTION
This pull request refactors and streamlines several core mechanisms in the `bsblan.py` module, focusing on code reuse, maintainability, and improved concurrency safety. Key improvements include consolidating parameter filtering and request logic, introducing a reusable locking helper for idempotent async operations, and centralizing payload construction for device commands.

### Concurrency and Locking Improvements
* Introduced a generic async helper method `_run_once_locked` to ensure that certain operations (like section/group validation) run at most once per key, preventing redundant concurrent work and reducing duplicated locking logic. This method is now used in `_ensure_section_validated` and `_ensure_hot_water_group_validated`. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R262-R295) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L282-R316) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R325-R331) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L340-L358) [[5]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R444-R450)

### Parameter Filtering and Request Handling
* Centralized parameter filtering logic into `_apply_include_filter`, which is now used throughout the codebase to consistently handle inclusion lists and error cases. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R1101-R1144) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1112-R1184) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1568-R1650) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1718-R1784)
* Added `_request_named_params` to encapsulate the logic for requesting parameters and re-keying responses by parameter name, improving clarity and reducing code duplication. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R1101-R1144) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1112-R1184) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1568-R1650)

### Payload Construction and State Setting
* Introduced `_set_payload` to standardize the construction of BSB-LAN `/JS` set-parameter payloads, replacing repeated inline dicts for setting device state. All relevant methods now use this helper, improving maintainability and reducing the risk of inconsistencies. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R1576-R1591) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1293-R1353) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1377-R1432) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1393-R1452) [[5]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1775-R1833) [[6]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1876-R1931) [[7]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1905-R1962)

### Validation Refactoring
* Consolidated temperature validation logic into a single `_validate_temperature_in_range` helper, which is now used by both `_validate_target_temperature` and `_validate_target_temperature_high`, reducing duplication and making it easier to extend or adjust validation rules. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1419-R1516) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1462-R1542)

### Type Hints and Imports
* Enhanced type safety and clarity by updating type hints and imports, including adding `Awaitable` and `Callable` to the imports for improved static analysis.