### PR TITLE
refactor: extract lazy section validation into SectionValidator

### DIFF
--- a/src/bsblan/_validation.py
+++ b/src/bsblan/_validation.py
@@ -1,0 +1,402 @@
+"""Lazy section/group validation for the BSBLAN client.
+
+Owns the on-demand validation of API sections and hot water parameter groups,
+including the per-key locks that serialize concurrent first-time validation,
+the set of already-validated hot water groups, and the hot water parameter
+cache. The owning client keeps thin ``_ensure_*`` / ``set_hot_water_cache``
+facades that delegate here.
+
+The validator reads the shared API config and performs requests through
+callables supplied by the owning client so it does not hold a back-reference to
+the facade. The temperature-unit extraction hooks are likewise injected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, cast
+
+from .constants import PPS_HEATING_PARAMS, PPS_STATIC_VALUES_PARAMS, ErrorMsg
+from .exceptions import BSBLANError
+from .utility import APIValidator
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from typing import Any
+
+    from .bsblan import SectionLiteral
+    from .constants import APIConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SectionValidator:
+    """Validate API sections and hot water groups on demand.
+
+    The validator owns the lazy-loading state (per-section/group locks, the
+    validated-group set, and the hot water parameter cache) and the wrapped
+    :class:`APIValidator`. Shared API config is read through ``get_api_data``
+    and device requests go through ``request`` so the validator never holds a
+    back-reference to the owning client.
+    """
+
+    def __init__(
+        self,
+        *,
+        request: Callable[..., Awaitable[dict[str, Any]]],
+        extract_params_summary: Callable[[dict[Any, Any]], dict[Any, Any]],
+        get_api_data: Callable[[], APIConfig | None],
+        should_extract_temperature_unit: Callable[
+            [SectionLiteral, list[str] | None, dict[str, Any]], bool
+        ],
+        extract_temperature_unit: Callable[[dict[str, Any]], None],
+    ) -> None:
+        """Initialize the validator with the client's collaborators.
+
+        Args:
+            request: Callable performing a device request, returning the JSON
+                response.
+            extract_params_summary: Callable building the request summary
+                (``string_par`` + value list) from a parameter map.
+            get_api_data: Callable returning the current shared API config.
+            should_extract_temperature_unit: Predicate deciding whether a
+                validation response should update the temperature unit.
+            extract_temperature_unit: Callable updating the temperature unit
+                from a validation response.
+
+        """
+        self._request = request
+        self._extract_params_summary = extract_params_summary
+        self._get_api_data = get_api_data
+        self._should_extract_temperature_unit = should_extract_temperature_unit
+        self._extract_temperature_unit = extract_temperature_unit
+
+        self._api_validator: APIValidator | None = None
+        # Cache of validated hot water parameter id -> name.
+        self._hot_water_param_cache: dict[str, str] = {}
+        # Track which hot water param groups have been validated.
+        self._validated_hot_water_groups: set[str] = set()
+        # Locks to prevent concurrent validation of the same section/group.
+        self._section_locks: dict[str, asyncio.Lock] = {}
+        self._hot_water_group_locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def hot_water_param_cache(self) -> dict[str, str]:
+        """Return the cache of validated hot water parameters."""
+        return self._hot_water_param_cache
+
+    def get_section_params(self, section: SectionLiteral) -> dict[str, str]:
+        """Return the validated parameter map for a section.
+
+        Args:
+            section: The section to read parameters for.
+
+        Returns:
+            dict[str, str]: Mapping of parameter id to parameter name.
+
+        """
+        return cast("APIValidator", self._api_validator).get_section_params(section)
+
+    def apply_bus_specific_api_config(
+        self, api_data: APIConfig | None, *, uses_pps_bus: bool
+    ) -> None:
+        """Apply bus-specific parameter maps to the current API config.
+
+        Args:
+            api_data: The shared API config to mutate in place.
+            uses_pps_bus: Whether the device uses the PPS bus.
+
+        """
+        if api_data is None or not uses_pps_bus:
+            return
+
+        api_data["heating"] = PPS_HEATING_PARAMS.copy()
+        api_data["staticValues"] = PPS_STATIC_VALUES_PARAMS.copy()
+        api_data["heating_circuit2"] = {}
+        api_data["staticValues_circuit2"] = {}
+
+    def setup(self, api_data: APIConfig, *, uses_pps_bus: bool) -> None:
+        """Create the API validator without validating sections.
+
+        This applies any bus-specific configuration and builds the validator
+        infrastructure but defers actual section validation until the data is
+        needed (lazy loading).
+
+        Args:
+            api_data: The shared API config to validate against.
+            uses_pps_bus: Whether the device uses the PPS bus.
+
+        """
+        self.apply_bus_specific_api_config(api_data, uses_pps_bus=uses_pps_bus)
+        self._api_validator = APIValidator(api_data)
+
+    async def _run_once_locked(
+        self,
+        key: str,
+        locks: dict[str, asyncio.Lock],
+        is_done: Callable[[], bool],
+        body: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Run an idempotent async operation at most once per key.
+
+        Implements double-checked locking: a fast path when the work is already
+        done, a per-key lock to serialize concurrent first-time callers, and a
+        re-check after acquiring the lock so only one caller runs ``body``.
+
+        Args:
+            key (str): Identifier for the one-time operation.
+            locks (dict[str, asyncio.Lock]): Registry of per-key locks, created
+                on demand.
+            is_done (Callable[[], bool]): Predicate returning True when the work
+                is already complete.
+            body (Callable[[], Awaitable[None]]): Coroutine factory executed once
+                while holding the lock.
+
+        """
+        if is_done():
+            return
+
+        if key not in locks:
+            locks[key] = asyncio.Lock()
+
+        async with locks[key]:
+            if is_done():
+                return
+            await body()
+
+    async def ensure_section_validated(
+        self, section: SectionLiteral, include: list[str] | None = None
+    ) -> None:
+        """Ensure a section is validated before use (lazy loading).
+
+        This method validates a section on-demand when it's first accessed.
+        Subsequent calls for the same section are no-ops.
+
+        Uses a per-section lock to prevent concurrent validation of the same
+        section, which could cause duplicate network requests.
+
+        Args:
+            section: The section name to validate
+            include: Optional list of parameter names to validate. If None,
+                validates all parameters for the section.
+
+        Raises:
+            BSBLANError: If the API validator is not initialized.
+
+        """
+        if not self._api_validator:
+            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
+
+        api_validator = self._api_validator
+
+        async def _validate() -> None:
+            logger.debug("Lazy loading section: %s", section)
+            response_data = await self._validate_api_section(section, include)
+
+            if response_data and self._should_extract_temperature_unit(
+                section, include, response_data
+            ):
+                self._extract_temperature_unit(response_data)
+
+        await self._run_once_locked(
+            section,
+            self._section_locks,
+            lambda: api_validator.is_section_validated(section),
+            _validate,
+        )
+
+    async def ensure_hot_water_group_validated(
+        self,
+        group_name: str,
+        param_filter: set[str],
+        include: list[str] | None = None,
+    ) -> None:
+        """Validate only a specific hot water parameter group (lazy loading).
+
+        This enables more granular lazy loading for hot water - instead of
+        validating all 29 hot water parameters at once, we only validate
+        the specific group needed (essential: 5, config: 16, schedule: 8).
+
+        Uses a per-group lock to prevent concurrent validation of the same
+        group, which could cause duplicate network requests.
+
+        Args:
+            group_name: Name of the group (essential, config, schedule)
+            param_filter: Set of parameter IDs for this group
+            include: Optional list of parameter names to include in validation.
+                If provided, only these parameters will be validated.
+
+        """
+
+        async def _validate() -> None:
+            if not self._api_validator:
+                raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
+
+            api_data = self._get_api_data()
+            if not api_data:
+                raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
+
+            logger.debug("Lazy loading hot water group: %s", group_name)
+
+            # Get the base hot water params from API config
+            section_data = api_data.get("hot_water", {})
+
+            # Filter to only the params in this group
+            group_params = {
+                param_id: param_name
+                for param_id, param_name in section_data.items()
+                if param_id in param_filter
+            }
+
+            # Apply include filter if specified - only validate requested params
+            if include is not None:
+                group_params = {
+                    param_id: name
+                    for param_id, name in group_params.items()
+                    if name in include
+                }
+
+            if not group_params:
+                logger.debug("No parameters to validate for group %s", group_name)
+                self._validated_hot_water_groups.add(group_name)
+                return
+
+            # Request only these specific parameters from the device
+            params = self._extract_params_summary(group_params)
+            response_data = await self._request(
+                params={"Parameter": params["string_par"]}
+            )
+
+            # Validate and filter out unsupported params
+            params_to_remove = []
+            for param_id, param_name in group_params.items():
+                if param_id not in response_data:
+                    logger.info(
+                        "Hot water param %s (%s) not found in response",
+                        param_id,
+                        param_name,
+                    )
+                    params_to_remove.append(param_id)
+                    continue
+
+                param_data = response_data[param_id]
+                if not param_data or param_data.get("value") in (None, "---"):
+                    logger.info(
+                        "Hot water param %s (%s) returned invalid value: %s",
+                        param_id,
+                        param_name,
+                        param_data.get("value") if param_data else None,
+                    )
+                    params_to_remove.append(param_id)
+
+            # Update the cache with validated params for this group
+            for param_id, param_name in group_params.items():
+                if param_id not in params_to_remove:
+                    self._hot_water_param_cache[param_id] = param_name
+
+            # Mark this group as validated
+            self._validated_hot_water_groups.add(group_name)
+            logger.debug(
+                "Validated hot water group '%s': %d params, removed %d unsupported",
+                group_name,
+                len(group_params),
+                len(params_to_remove),
+            )
+
+        await self._run_once_locked(
+            group_name,
+            self._hot_water_group_locks,
+            lambda: group_name in self._validated_hot_water_groups,
+            _validate,
+        )
+
+    async def _validate_api_section(
+        self, section: SectionLiteral, include: list[str] | None = None
+    ) -> dict[str, Any] | None:
+        """Validate a specific section of the API configuration.
+
+        Args:
+            section: The section name to validate
+            include: Optional list of parameter names to validate. If None,
+                validates all parameters for the section.
+
+        Returns:
+            dict[str, Any] | None: The response data from the device, or None if
+                section was already validated or validation failed
+
+        Raises:
+            BSBLANError: If the API validator or API data is not initialized,
+                or the section is not found.
+
+        """
+        if not self._api_validator:
+            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
+
+        api_data = self._get_api_data()
+        if not api_data:
+            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
+
+        # Assign to local variable after asserting it's not None
+        api_validator = self._api_validator
+
+        if api_validator.is_section_validated(section):
+            return None
+
+        # Get parameters for the section
+        try:
+            section_data = api_data[section]
+        except KeyError as err:
+            msg = ErrorMsg.SECTION_NOT_FOUND.format(section)
+            raise BSBLANError(msg) from err
+
+        # Filter to only included params if specified
+        if include is not None:
+            section_data = {
+                param_id: name
+                for param_id, name in section_data.items()
+                if name in include
+            }
+
+        try:
+            # Request data from device for validation
+            params = self._extract_params_summary(section_data)
+            response_data = await self._request(
+                params={"Parameter": params["string_par"]}
+            )
+
+            # Validate the section against actual device response
+            api_validator.validate_section(section, response_data, include)
+            # Update API data with validated configuration
+            api_data[section] = api_validator.get_section_params(section)
+
+            # Cache hot water parameters if this is the hot_water section
+            if section == "hot_water":
+                self.populate_hot_water_cache()
+        except BSBLANError as err:
+            logger.warning("Failed to validate section %s: %s", section, str(err))
+            # Reset validation state for this section
+            api_validator.reset_validation(section)
+            raise
+        else:
+            return response_data
+
+    def populate_hot_water_cache(self) -> None:
+        """Populate the hot water parameter cache with all available parameters."""
+        if not self._api_validator:
+            return
+
+        # Get all hot water parameters and cache them
+        hotwater_params = self._api_validator.get_section_params("hot_water")
+        self._hot_water_param_cache = hotwater_params.copy()
+        logger.debug("Cached %d hot water parameters", len(self._hot_water_param_cache))
+
+    def set_hot_water_cache(self, params: dict[str, str]) -> None:
+        """Set the hot water parameter cache manually (for testing).
+
+        Args:
+            params: Dictionary of parameter_id -> parameter_name mappings
+
+        """
+        self._hot_water_param_cache = params.copy()
+        logger.debug("Manually set cache with %d hot water parameters", len(params))

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -2,25 +2,23 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Mapping
+    from collections.abc import Mapping
 
 import aiohttp
 from aiohttp.hdrs import METH_POST
 
 from ._transport import BSBLANTransport
+from ._validation import SectionValidator
 from ._version import VersionResolver
 from .constants import (
     API_V2,
     API_V3,
     BASIC_API_VERSION,
-    PPS_HEATING_PARAMS,
-    PPS_STATIC_VALUES_PARAMS,
     SUPPORTED_API_VERSION,
     SUPPORTED_API_VERSIONS,
     APIConfig,
@@ -54,7 +52,7 @@ from .models import (
     State,
     StaticState,
 )
-from .utility import APIValidator, validate_time_format
+from .utility import validate_time_format
 
 if TYPE_CHECKING:
     from typing import Self
@@ -107,7 +105,6 @@ class BSBLAN:
     _api_data: APIConfig | None = None
     _device: Device | None = None
     _initialized: bool = False
-    _api_validator: APIValidator = field(init=False)
     _temperature_unit: str = "°C"
     # Per-circuit temperature ranges: circuit_number -> {min, max}
     _circuit_temp_ranges: dict[int, dict[str, float | None]] = field(
@@ -115,14 +112,9 @@ class BSBLAN:
     )
     _circuit_temp_initialized: set[int] = field(default_factory=set)
     _available_circuits: set[int] | None = None
-    _hot_water_param_cache: dict[str, str] = field(default_factory=dict)
-    # Track which hot water param groups have been validated
-    _validated_hot_water_groups: set[str] = field(default_factory=set)
-    # Locks to prevent concurrent validation of the same section/group
-    _section_locks: dict[str, asyncio.Lock] = field(default_factory=dict)
-    _hot_water_group_locks: dict[str, asyncio.Lock] = field(default_factory=dict)
     _transport: BSBLANTransport = field(init=False)
     _version_resolver: VersionResolver = field(init=False)
+    _validator: SectionValidator = field(init=False)
 
     def __post_init__(self) -> None:
         """Wire up internal collaborators after dataclass construction."""
@@ -132,6 +124,17 @@ class BSBLAN:
             lambda: self._firmware_version,
         )
         self._version_resolver = VersionResolver()
+        # _request and _extract_params_summary are monkeypatched by some tests,
+        # so resolve them lazily instead of binding them at construction time.
+        self._validator = SectionValidator(
+            request=lambda **kw: self._request(**kw),  # noqa: PLW0108
+            extract_params_summary=(
+                lambda d: self._extract_params_summary(d)  # noqa: PLW0108
+            ),
+            get_api_data=lambda: self._api_data,
+            should_extract_temperature_unit=self._should_extract_temperature_unit,
+            extract_temperature_unit=self._extract_temperature_unit_from_response,
+        )
 
     async def __aenter__(self) -> Self:
         """Enter the context manager.
@@ -247,54 +250,14 @@ class BSBLAN:
         if self._api_data is None:
             self._api_data = self._copy_api_config()
 
-        self._apply_bus_specific_api_config()
-
-        # Initialize the API validator (but don't validate sections yet)
-        self._api_validator = APIValidator(self._api_data)
+        # Build the validator (applies bus-specific config, defers validation)
+        self._validator.setup(self._api_data, uses_pps_bus=self._uses_pps_bus)
 
     def _apply_bus_specific_api_config(self) -> None:
         """Apply bus-specific parameter maps to the current API config."""
-        if self._api_data is None or not self._uses_pps_bus:
-            return
-
-        self._api_data["heating"] = PPS_HEATING_PARAMS.copy()
-        self._api_data["staticValues"] = PPS_STATIC_VALUES_PARAMS.copy()
-        self._api_data["heating_circuit2"] = {}
-        self._api_data["staticValues_circuit2"] = {}
-
-    async def _run_once_locked(
-        self,
-        key: str,
-        locks: dict[str, asyncio.Lock],
-        is_done: Callable[[], bool],
-        body: Callable[[], Awaitable[None]],
-    ) -> None:
-        """Run an idempotent async operation at most once per key.
-
-        Implements double-checked locking: a fast path when the work is already
-        done, a per-key lock to serialize concurrent first-time callers, and a
-        re-check after acquiring the lock so only one caller runs ``body``.
-
-        Args:
-            key (str): Identifier for the one-time operation.
-            locks (dict[str, asyncio.Lock]): Registry of per-key locks, created
-                on demand.
-            is_done (Callable[[], bool]): Predicate returning True when the work
-                is already complete.
-            body (Callable[[], Awaitable[None]]): Coroutine factory executed once
-                while holding the lock.
-
-        """
-        if is_done():
-            return
-
-        if key not in locks:
-            locks[key] = asyncio.Lock()
-
-        async with locks[key]:
-            if is_done():
-                return
-            await body()
+        self._validator.apply_bus_specific_api_config(
+            self._api_data, uses_pps_bus=self._uses_pps_bus
+        )
 
     async def _ensure_section_validated(
         self, section: SectionLiteral, include: list[str] | None = None
@@ -313,24 +276,7 @@ class BSBLAN:
                 validates all parameters for the section.
 
         """
-        if not self._api_validator:
-            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
-
-        async def _validate() -> None:
-            logger.debug("Lazy loading section: %s", section)
-            response_data = await self._validate_api_section(section, include)
-
-            if response_data and self._should_extract_temperature_unit(
-                section, include, response_data
-            ):
-                self._extract_temperature_unit_from_response(response_data)
-
-        await self._run_once_locked(
-            section,
-            self._section_locks,
-            lambda: self._api_validator.is_section_validated(section),
-            _validate,
-        )
+        await self._validator.ensure_section_validated(section, include)
 
     def _should_extract_temperature_unit(
         self,
@@ -369,166 +315,13 @@ class BSBLAN:
                 If provided, only these parameters will be validated.
 
         """
-
-        async def _validate() -> None:
-            if not self._api_validator:
-                raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
-
-            if not self._api_data:
-                raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
-
-            logger.debug("Lazy loading hot water group: %s", group_name)
-
-            # Get the base hot water params from API config
-            section_data = self._api_data.get("hot_water", {})
-
-            # Filter to only the params in this group
-            group_params = {
-                param_id: param_name
-                for param_id, param_name in section_data.items()
-                if param_id in param_filter
-            }
-
-            # Apply include filter if specified - only validate requested params
-            if include is not None:
-                group_params = {
-                    param_id: name
-                    for param_id, name in group_params.items()
-                    if name in include
-                }
-
-            if not group_params:
-                logger.debug("No parameters to validate for group %s", group_name)
-                self._validated_hot_water_groups.add(group_name)
-                return
-
-            # Request only these specific parameters from the device
-            params = self._extract_params_summary(group_params)
-            response_data = await self._request(
-                params={"Parameter": params["string_par"]}
-            )
-
-            # Validate and filter out unsupported params
-            params_to_remove = []
-            for param_id, param_name in group_params.items():
-                if param_id not in response_data:
-                    logger.info(
-                        "Hot water param %s (%s) not found in response",
-                        param_id,
-                        param_name,
-                    )
-                    params_to_remove.append(param_id)
-                    continue
-
-                param_data = response_data[param_id]
-                if not param_data or param_data.get("value") in (None, "---"):
-                    logger.info(
-                        "Hot water param %s (%s) returned invalid value: %s",
-                        param_id,
-                        param_name,
-                        param_data.get("value") if param_data else None,
-                    )
-                    params_to_remove.append(param_id)
-
-            # Update the cache with validated params for this group
-            for param_id, param_name in group_params.items():
-                if param_id not in params_to_remove:
-                    self._hot_water_param_cache[param_id] = param_name
-
-            # Mark this group as validated
-            self._validated_hot_water_groups.add(group_name)
-            logger.debug(
-                "Validated hot water group '%s': %d params, removed %d unsupported",
-                group_name,
-                len(group_params),
-                len(params_to_remove),
-            )
-
-        await self._run_once_locked(
-            group_name,
-            self._hot_water_group_locks,
-            lambda: group_name in self._validated_hot_water_groups,
-            _validate,
+        await self._validator.ensure_hot_water_group_validated(
+            group_name, param_filter, include
         )
-
-    async def _validate_api_section(
-        self, section: SectionLiteral, include: list[str] | None = None
-    ) -> dict[str, Any] | None:
-        """Validate a specific section of the API configuration.
-
-        Args:
-            section: The section name to validate
-            include: Optional list of parameter names to validate. If None,
-                validates all parameters for the section.
-
-        Returns:
-            dict[str, Any] | None: The response data from the device, or None if
-                section was already validated or validation failed
-
-        Raises:
-            BSBLANError: If the API validator is not initialized
-
-        """
-        if not self._api_validator:
-            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
-
-        if not self._api_data:
-            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
-
-        # Assign to local variable after asserting it's not None
-        api_validator = self._api_validator
-
-        if api_validator.is_section_validated(section):
-            return None
-
-        # Get parameters for the section
-        try:
-            section_data = self._api_data[section]
-        except KeyError as err:
-            msg = ErrorMsg.SECTION_NOT_FOUND.format(section)
-            raise BSBLANError(msg) from err
-
-        # Filter to only included params if specified
-        if include is not None:
-            section_data = {
-                param_id: name
-                for param_id, name in section_data.items()
-                if name in include
-            }
-
-        try:
-            # Request data from device for validation
-            params = self._extract_params_summary(section_data)
-            response_data = await self._request(
-                params={"Parameter": params["string_par"]}
-            )
-
-            # Validate the section against actual device response
-            api_validator.validate_section(section, response_data, include)
-            # Update API data with validated configuration
-            if self._api_data:
-                self._api_data[section] = api_validator.get_section_params(section)
-
-            # Cache hot water parameters if this is the hot_water section
-            if section == "hot_water":
-                self._populate_hot_water_cache()
-        except BSBLANError as err:
-            logger.warning("Failed to validate section %s: %s", section, str(err))
-            # Reset validation state for this section
-            api_validator.reset_validation(section)
-            raise
-        else:
-            return response_data
 
     def _populate_hot_water_cache(self) -> None:
         """Populate the hot water parameter cache with all available parameters."""
-        if not self._api_validator:
-            return
-
-        # Get all hot water parameters and cache them
-        hotwater_params = self._api_validator.get_section_params("hot_water")
-        self._hot_water_param_cache = hotwater_params.copy()
-        logger.debug("Cached %d hot water parameters", len(self._hot_water_param_cache))
+        self._validator.populate_hot_water_cache()
 
     def _extract_temperature_unit_from_response(
         self, response_data: dict[str, Any]
@@ -572,8 +365,7 @@ class BSBLAN:
             params: Dictionary of parameter_id -> parameter_name mappings
 
         """
-        self._hot_water_param_cache = params.copy()
-        logger.debug("Manually set cache with %d hot water parameters", len(params))
+        self._validator.set_hot_water_cache(params)
 
     async def _fetch_firmware_version(self) -> None:
         """Fetch the firmware version if not already available."""
@@ -997,7 +789,7 @@ class BSBLAN:
         # Lazy load: validate section on first access (only for included params)
         await self._ensure_section_validated(section, include)
 
-        section_params = self._api_validator.get_section_params(section)
+        section_params = self._validator.get_section_params(section)
 
         # Guard: if validation removed all params, the section is not available
         if not section_params:
@@ -1463,7 +1255,7 @@ class BSBLAN:
         # Use cached validated params
         filtered_params = {
             param_id: param_name
-            for param_id, param_name in self._hot_water_param_cache.items()
+            for param_id, param_name in self._validator.hot_water_param_cache.items()
             if param_id in param_filter
         }
 

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -67,13 +67,13 @@ async def test_validate_api_section_success(aresponses: ResponsesMockServer) -> 
             }
         }
         bsblan._api_data = {"device": api_data_device_section}  # type: ignore[assignment]
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         # Test validation
-        await bsblan._validate_api_section("device")
+        await bsblan._validator._validate_api_section("device")
 
         # Verify validation status
-        assert bsblan._api_validator.is_section_validated("device")
+        assert bsblan._validator._api_validator.is_section_validated("device")
 
 
 @pytest.mark.asyncio
@@ -83,10 +83,10 @@ async def test_validate_api_section_no_validator() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
 
         # Ensure validator is None
-        bsblan._api_validator = None  # type: ignore[assignment]
+        bsblan._validator._api_validator = None  # type: ignore[assignment]
 
         with pytest.raises(BSBLANError, match=ErrorMsg.API_VALIDATOR_NOT_INITIALIZED):
-            await bsblan._validate_api_section("device")
+            await bsblan._validator._validate_api_section("device")
 
 
 @pytest.mark.asyncio
@@ -96,11 +96,11 @@ async def test_validate_api_section_no_api_data() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
 
         # Initialize validator but not API data
-        bsblan._api_validator = APIValidator({})
+        bsblan._validator._api_validator = APIValidator({})
         bsblan._api_data = None
 
         with pytest.raises(BSBLANError, match=ErrorMsg.API_DATA_NOT_INITIALIZED):
-            await bsblan._validate_api_section("device")
+            await bsblan._validator._validate_api_section("device")
 
 
 @pytest.mark.asyncio
@@ -110,13 +110,13 @@ async def test_validate_api_section_invalid_section() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
 
         # Initialize validator and API data without the requested section
-        bsblan._api_validator = APIValidator({})
+        bsblan._validator._api_validator = APIValidator({})
         bsblan._api_data = {"heating": {}}  # type: ignore[assignment]
 
         with pytest.raises(
             BSBLANError, match="Section 'invalid_section' not found in API data"
         ):
-            await bsblan._validate_api_section("invalid_section")  # type: ignore[arg-type]
+            await bsblan._validator._validate_api_section("invalid_section")  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio
@@ -158,8 +158,8 @@ async def test_validate_api_section_validation_error(
         bsblan._api_data = {"device": api_data_device_section_error}  # type: ignore[assignment]
 
         original_validate = APIValidator.validate_section
-        # Initialize bsblan._api_validator with the full _api_data
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        # Initialize the validator's APIValidator with the full _api_data
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         def mock_validate(
             _self: APIValidator,
@@ -181,9 +181,9 @@ async def test_validate_api_section_validation_error(
             bsblan._extract_params_summary = mock_extract_params  # type: ignore[assignment, method-assign]
             # Handle the exception because we expect it
             with contextlib.suppress(BSBLANError):
-                await bsblan._validate_api_section("device")
+                await bsblan._validator._validate_api_section("device")
 
-            assert not bsblan._api_validator.is_section_validated("device")
+            assert not bsblan._validator._api_validator.is_section_validated("device")
         finally:
             APIValidator.validate_section = original_validate
 
@@ -205,7 +205,7 @@ async def test_validate_section_already_validated(monkeypatch: Any) -> None:
                 for section, params in source_config.items()
             },
         )
-        client._api_validator = APIValidator(client._api_data)
+        client._validator._api_validator = APIValidator(client._api_data)
 
         # Mock request
         request_mock: AsyncMock = AsyncMock(
@@ -214,11 +214,11 @@ async def test_validate_section_already_validated(monkeypatch: Any) -> None:
         monkeypatch.setattr(client, "_request", request_mock)
 
         # First validation should succeed
-        response_data = await client._validate_api_section("heating")
+        response_data = await client._validator._validate_api_section("heating")
         assert response_data is not None
 
         # Second call should return None (already validated)
-        response_data = await client._validate_api_section("heating")
+        response_data = await client._validator._validate_api_section("heating")
         assert response_data is None
 
 
@@ -239,7 +239,7 @@ async def test_validation_error_resets_section(monkeypatch: Any) -> None:
                 for section, params in source_config.items()
             },
         )
-        client._api_validator = APIValidator(client._api_data)
+        client._validator._api_validator = APIValidator(client._api_data)
 
         # Mock request to raise an error
         request_mock: AsyncMock = AsyncMock(side_effect=BSBLANError("Test error"))
@@ -247,7 +247,7 @@ async def test_validation_error_resets_section(monkeypatch: Any) -> None:
 
         # This should raise BSBLANError and reset validation
         with pytest.raises(BSBLANError, match="Test error"):
-            await client._validate_api_section("heating")
+            await client._validator._validate_api_section("heating")
 
 
 @pytest.mark.asyncio
@@ -265,7 +265,7 @@ async def test_setup_api_validator_api_data_already_exists() -> None:
 
         # _api_data should remain unchanged (not overwritten)
         assert bsblan._api_data is existing_data
-        assert bsblan._api_validator is not None
+        assert bsblan._validator._api_validator is not None
 
 
 @pytest.mark.asyncio
@@ -283,7 +283,7 @@ async def test_setup_api_validator_initializes_api_data() -> None:
         # _api_data should be initialized from API config
         assert bsblan._api_data is not None
         assert "heating" in bsblan._api_data
-        assert bsblan._api_validator is not None
+        assert bsblan._validator._api_validator is not None
 
 
 @pytest.mark.asyncio
@@ -293,7 +293,7 @@ async def test_ensure_section_validated_double_check_after_lock() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._api_version = "v3"
         bsblan._api_data = {"heating": {"700": "operating_mode"}}  # type: ignore[assignment]
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         # Track validation calls
         validation_count = 0
@@ -304,13 +304,13 @@ async def test_ensure_section_validated_double_check_after_lock() -> None:
             nonlocal validation_count
             validation_count += 1
             # Mark section as validated
-            bsblan._api_validator.validated_sections.add(section)
+            bsblan._validator._api_validator.validated_sections.add(section)
             return {}
 
-        bsblan._validate_api_section = mock_validate  # type: ignore[method-assign]
+        bsblan._validator._validate_api_section = mock_validate  # type: ignore[method-assign]
 
         # Create the lock first
-        bsblan._section_locks["heating"] = asyncio.Lock()
+        bsblan._validator._section_locks["heating"] = asyncio.Lock()
 
         # First call validates
         await bsblan._ensure_section_validated("heating")
@@ -328,7 +328,7 @@ async def test_ensure_section_validated_concurrent_double_check() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._api_version = "v3"
         bsblan._api_data = {"heating": {"700": "operating_mode"}}  # type: ignore[assignment]
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         validation_count = 0
         validation_started = asyncio.Event()
@@ -341,10 +341,10 @@ async def test_ensure_section_validated_concurrent_double_check() -> None:
             validation_started.set()
             # Simulate slow validation
             await asyncio.sleep(0.1)
-            bsblan._api_validator.validated_sections.add(section)
+            bsblan._validator._api_validator.validated_sections.add(section)
             return {}
 
-        bsblan._validate_api_section = slow_validate  # type: ignore[method-assign]
+        bsblan._validator._validate_api_section = slow_validate  # type: ignore[method-assign]
 
         # Start two concurrent validations
         task1 = asyncio.create_task(bsblan._ensure_section_validated("heating"))
@@ -373,7 +373,7 @@ async def test_validate_api_section_hot_water_cache() -> None:
             "heating_circuit2": {},
             "staticValues_circuit2": {},
         }
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         # Mock the request
         bsblan._request = AsyncMock(  # type: ignore[method-assign]
@@ -384,10 +384,10 @@ async def test_validate_api_section_hot_water_cache() -> None:
         )
 
         # Validate hot_water section
-        await bsblan._validate_api_section("hot_water")
+        await bsblan._validator._validate_api_section("hot_water")
 
         # Cache should be populated
-        assert len(bsblan._hot_water_param_cache) > 0
+        assert len(bsblan._validator._hot_water_param_cache) > 0
 
 
 @pytest.mark.asyncio
@@ -397,18 +397,18 @@ async def test_ensure_section_validated_heating_extracts_temp_unit() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._api_version = "v3"
         bsblan._api_data = {"heating": {"710": "target_temperature"}}  # type: ignore[assignment]
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         # Mock _validate_api_section to return response with temp unit
         async def mock_validate(
             section: str, _include: list[str] | None = None
         ) -> dict[str, Any]:
-            bsblan._api_validator.validated_sections.add(section)
+            bsblan._validator._api_validator.validated_sections.add(section)
             if section == "heating":
                 return {"710": {"value": "20.0", "unit": "°F"}}
             return {}
 
-        bsblan._validate_api_section = mock_validate  # type: ignore[method-assign]
+        bsblan._validator._validate_api_section = mock_validate  # type: ignore[method-assign]
 
         await bsblan._ensure_section_validated("heating")
 

--- a/tests/test_bsblan_edge_cases.py
+++ b/tests/test_bsblan_edge_cases.py
@@ -27,7 +27,7 @@ async def test_validate_api_section_key_error(monkeypatch: Any) -> None:
         # Mock API validator
         mock_validator = MagicMock()
         mock_validator.is_section_validated.return_value = False
-        bsblan._api_validator = mock_validator
+        bsblan._validator._api_validator = mock_validator
 
         # Mock request to avoid network calls
         request_mock = AsyncMock(return_value={})
@@ -38,7 +38,7 @@ async def test_validate_api_section_key_error(monkeypatch: Any) -> None:
             BSBLANError,
             match="Section 'nonexistent' not found in API data",
         ):
-            await bsblan._validate_api_section("nonexistent")  # type: ignore[arg-type]
+            await bsblan._validator._validate_api_section("nonexistent")  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio
@@ -90,4 +90,4 @@ def test_bsblan_config_initialization_edge_cases() -> None:
     # Verify initial state
     assert bsblan.session is None
     assert bsblan._initialized is False
-    assert len(bsblan._hot_water_param_cache) == 0
+    assert len(bsblan._validator._hot_water_param_cache) == 0

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -44,7 +44,7 @@ async def mock_bsblan_circuit() -> AsyncGenerator[BSBLAN, None]:
         api_validator.validated_sections.add("heating_circuit2")
         api_validator.validated_sections.add("staticValues")
         api_validator.validated_sections.add("staticValues_circuit2")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         yield bsblan
 
@@ -91,7 +91,7 @@ async def test_state_circuit1_default(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(api_data)
         api_validator.validated_sections.add("heating")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock = AsyncMock(
             return_value=json.loads(load_fixture("state.json")),
@@ -127,7 +127,7 @@ async def test_state_circuit2(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(bsblan._api_data)
         api_validator.validated_sections.add("heating_circuit2")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock = AsyncMock(
             return_value=json.loads(
@@ -168,7 +168,7 @@ async def test_state_circuit2_with_include(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(bsblan._api_data)
         api_validator.validated_sections.add("heating_circuit2")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Only return hvac_mode data
         request_mock = AsyncMock(
@@ -213,7 +213,7 @@ async def test_static_values_circuit2(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(bsblan._api_data)
         api_validator.validated_sections.add("staticValues_circuit2")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock = AsyncMock(
             return_value=json.loads(
@@ -479,7 +479,7 @@ async def test_circuit2_temp_range_initialization(
 
         api_validator = APIValidator(bsblan._api_data)
         api_validator.validated_sections.add("staticValues_circuit2")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         static_fixture = json.loads(
             load_fixture("static_state_circuit2.json"),
@@ -515,7 +515,7 @@ async def test_circuit1_temp_range_uses_protective_lower_bound(
 
         api_validator = APIValidator(api_data)
         api_validator.validated_sections.add("staticValues")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         static_fixture = json.loads(
             load_fixture("static_state.json"),
@@ -558,7 +558,7 @@ async def test_thermostat_circuit2_lazy_temp_init(
         api_validator = APIValidator(bsblan._api_data)
         api_validator.validated_sections.add("staticValues_circuit2")
         api_validator.validated_sections.add("heating_circuit2")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # First: mock _request to return static values for temp range
         static_fixture = json.loads(
@@ -799,9 +799,9 @@ async def test_state_empty_section_after_validation(
     bsblan = mock_bsblan_circuit
 
     # Simulate validation removing all params for heating_circuit2
-    assert bsblan._api_validator is not None
-    bsblan._api_validator.api_config["heating_circuit2"] = {}  # type: ignore[index]
-    bsblan._api_validator.validated_sections.add("heating_circuit2")
+    assert bsblan._validator._api_validator is not None
+    bsblan._validator._api_validator.api_config["heating_circuit2"] = {}  # type: ignore[index]
+    bsblan._validator._api_validator.validated_sections.add("heating_circuit2")
 
     with pytest.raises(BSBLANError, match="No valid parameters found"):
         await bsblan.state(circuit=2)

--- a/tests/test_hot_water_additional.py
+++ b/tests/test_hot_water_additional.py
@@ -33,7 +33,7 @@ async def test_hot_water_config(
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("hot_water")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Set up the hot water parameter cache
         hot_water_cache = {
@@ -49,7 +49,7 @@ async def test_hot_water_config(
         bsblan.set_hot_water_cache(hot_water_cache)
 
         # Mark config group as validated to skip validation logic
-        bsblan._validated_hot_water_groups.add("config")
+        bsblan._validator._validated_hot_water_groups.add("config")
 
         # Mock the request response
         fixture_data: dict[str, Any] = json.loads(load_fixture("hot_water_state.json"))
@@ -95,13 +95,13 @@ async def test_hot_water_config_no_params_error(
         # Create a mock API validator that returns empty parameters
         mock_validator = MagicMock()
         mock_validator.get_section_params.return_value = {}
-        bsblan._api_validator = mock_validator
+        bsblan._validator._api_validator = mock_validator
 
         # Set empty cache - no config parameters available
         bsblan.set_hot_water_cache({})
 
         # Mark config group as already validated (so it skips validation)
-        bsblan._validated_hot_water_groups.add("config")
+        bsblan._validator._validated_hot_water_groups.add("config")
 
         with pytest.raises(
             BSBLANError,
@@ -125,7 +125,7 @@ async def test_hot_water_schedule(
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("hot_water")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Set up the hot water parameter cache with schedule parameters
         hot_water_cache = {
@@ -141,7 +141,7 @@ async def test_hot_water_schedule(
         bsblan.set_hot_water_cache(hot_water_cache)
 
         # Mark schedule group as validated to skip validation logic
-        bsblan._validated_hot_water_groups.add("schedule")
+        bsblan._validator._validated_hot_water_groups.add("schedule")
 
         # Create mock fixture data for schedule parameters
         schedule_fixture_data = {
@@ -244,13 +244,13 @@ async def test_hot_water_schedule_no_params_error(
         # Create a mock API validator that returns empty parameters
         mock_validator = MagicMock()
         mock_validator.get_section_params.return_value = {}
-        bsblan._api_validator = mock_validator
+        bsblan._validator._api_validator = mock_validator
 
         # Set empty cache - no schedule parameters available
         bsblan.set_hot_water_cache({})
 
         # Mark schedule group as already validated (so it skips validation)
-        bsblan._validated_hot_water_groups.add("schedule")
+        bsblan._validator._validated_hot_water_groups.add("schedule")
 
         with pytest.raises(
             BSBLANError,
@@ -274,13 +274,13 @@ async def test_hot_water_state_no_params_error(
         # Create a mock API validator that returns empty parameters
         mock_validator = MagicMock()
         mock_validator.get_section_params.return_value = {}
-        bsblan._api_validator = mock_validator
+        bsblan._validator._api_validator = mock_validator
 
         # Set empty cache - no essential parameters available
         bsblan.set_hot_water_cache({})
 
         # Mark essential group as already validated (so it skips validation)
-        bsblan._validated_hot_water_groups.add("essential")
+        bsblan._validator._validated_hot_water_groups.add("essential")
 
         with pytest.raises(
             BSBLANError,
@@ -303,7 +303,7 @@ async def test_granular_hot_water_validation(
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Mock the request to return valid hot water params
         fixture_data: dict[str, Any] = json.loads(load_fixture("hot_water_state.json"))
@@ -324,18 +324,18 @@ async def test_granular_hot_water_validation(
         monkeypatch.setattr(bsblan, "_request", request_mock)
 
         # Initially no groups validated
-        assert len(bsblan._validated_hot_water_groups) == 0
+        assert len(bsblan._validator._validated_hot_water_groups) == 0
 
         # Call hot_water_state - should validate essential group only
         await bsblan.hot_water_state()
 
         # Essential group should be validated
-        assert "essential" in bsblan._validated_hot_water_groups
-        assert "config" not in bsblan._validated_hot_water_groups
-        assert "schedule" not in bsblan._validated_hot_water_groups
+        assert "essential" in bsblan._validator._validated_hot_water_groups
+        assert "config" not in bsblan._validator._validated_hot_water_groups
+        assert "schedule" not in bsblan._validator._validated_hot_water_groups
 
         # Cache should have essential params only
-        assert len(bsblan._hot_water_param_cache) > 0
+        assert len(bsblan._validator._hot_water_param_cache) > 0
 
 
 @pytest.mark.asyncio
@@ -354,13 +354,13 @@ async def test_granular_validation_empty_params(
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
         api_validator = APIValidator(api_data)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Validation should complete without error even with empty params
         await bsblan._ensure_hot_water_group_validated("essential", {"1600", "1610"})
 
         # Group should be marked as validated
-        assert "essential" in bsblan._validated_hot_water_groups
+        assert "essential" in bsblan._validator._validated_hot_water_groups
 
 
 @pytest.mark.asyncio
@@ -370,13 +370,13 @@ async def test_populate_hot_water_cache_no_validator() -> None:
     bsblan = BSBLAN(config)
 
     # Ensure no validator is set
-    bsblan._api_validator = None  # type: ignore[assignment]
+    bsblan._validator._api_validator = None  # type: ignore[assignment]
 
     # Should not raise an error, just return without doing anything
     bsblan._populate_hot_water_cache()
 
     # Cache should still be empty
-    assert len(bsblan._hot_water_param_cache) == 0
+    assert len(bsblan._validator._hot_water_param_cache) == 0
 
 
 @pytest.mark.asyncio
@@ -387,7 +387,7 @@ async def test_ensure_hot_water_group_validated_no_validator() -> None:
         bsblan = BSBLAN(config, session=session)
 
         # No validator set
-        bsblan._api_validator = None  # type: ignore[assignment]
+        bsblan._validator._api_validator = None  # type: ignore[assignment]
 
         with pytest.raises(BSBLANError, match="API validator not initialized"):
             await bsblan._ensure_hot_water_group_validated("essential", {"1600"})
@@ -401,7 +401,7 @@ async def test_ensure_hot_water_group_validated_no_api_data() -> None:
         bsblan = BSBLAN(config, session=session)
 
         # Set validator but no api_data
-        bsblan._api_validator = MagicMock()
+        bsblan._validator._api_validator = MagicMock()
         bsblan._api_data = None
 
         with pytest.raises(BSBLANError, match="API data not initialized"):
@@ -416,7 +416,7 @@ async def test_ensure_section_validated_no_validator() -> None:
         bsblan = BSBLAN(config, session=session)
 
         # No validator set
-        bsblan._api_validator = None  # type: ignore[assignment]
+        bsblan._validator._api_validator = None  # type: ignore[assignment]
 
         with pytest.raises(BSBLANError, match="API validator not initialized"):
             await bsblan._ensure_section_validated("heating")
@@ -450,7 +450,7 @@ async def test_granular_validation_filters_missing_params(
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Mock response that's missing param "1610"
         mock_response = {
@@ -465,9 +465,9 @@ async def test_granular_validation_filters_missing_params(
         await bsblan._ensure_hot_water_group_validated("test_missing", {"1600", "1610"})
 
         # Only "1600" should be in cache (1610 was missing)
-        assert "1600" in bsblan._hot_water_param_cache
-        assert "1610" not in bsblan._hot_water_param_cache
-        assert "test_missing" in bsblan._validated_hot_water_groups
+        assert "1600" in bsblan._validator._hot_water_param_cache
+        assert "1610" not in bsblan._validator._hot_water_param_cache
+        assert "test_missing" in bsblan._validator._validated_hot_water_groups
 
 
 @pytest.mark.asyncio
@@ -484,7 +484,7 @@ async def test_granular_validation_filters_invalid_params(
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Mock response with invalid values
         mock_response = {
@@ -502,10 +502,10 @@ async def test_granular_validation_filters_invalid_params(
         )
 
         # Only "1600" should be in cache (others had invalid values)
-        assert "1600" in bsblan._hot_water_param_cache
-        assert "1610" not in bsblan._hot_water_param_cache  # value was "---"
-        assert "1620" not in bsblan._hot_water_param_cache  # value was None
-        assert "test_invalid" in bsblan._validated_hot_water_groups
+        assert "1600" in bsblan._validator._hot_water_param_cache
+        assert "1610" not in bsblan._validator._hot_water_param_cache  # value was "---"
+        assert "1620" not in bsblan._validator._hot_water_param_cache  # value was None
+        assert "test_invalid" in bsblan._validator._validated_hot_water_groups
 
 
 @pytest.mark.asyncio
@@ -515,7 +515,7 @@ async def test_ensure_hot_water_group_double_check_after_lock() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._api_version = "v3"
         bsblan._api_data = {"hot_water": {"1600": "operating_mode"}}  # type: ignore[assignment]
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         # Mock the request
         bsblan._request = AsyncMock(  # type: ignore[method-assign]
@@ -523,11 +523,11 @@ async def test_ensure_hot_water_group_double_check_after_lock() -> None:
         )
 
         # Create the lock first
-        bsblan._hot_water_group_locks["essential"] = asyncio.Lock()
+        bsblan._validator._hot_water_group_locks["essential"] = asyncio.Lock()
 
         # First call validates
         await bsblan._ensure_hot_water_group_validated("essential", {"1600"})
-        assert "essential" in bsblan._validated_hot_water_groups
+        assert "essential" in bsblan._validator._validated_hot_water_groups
 
         # Second call should hit the fast path (before lock)
         bsblan._request.reset_mock()  # type: ignore[attr-defined]
@@ -542,7 +542,7 @@ async def test_ensure_hot_water_group_concurrent_double_check() -> None:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._api_version = "v3"
         bsblan._api_data = {"hot_water": {"1600": "operating_mode"}}  # type: ignore[assignment]
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         request_count = 0
         request_started = asyncio.Event()
@@ -587,7 +587,7 @@ async def test_ensure_hot_water_group_validated_with_include_filter() -> None:
                 "1648": "legionella_circulation_temp_diff",
             }
         }
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         requested_params: list[str] = []
 
@@ -619,9 +619,9 @@ async def test_ensure_hot_water_group_validated_with_include_filter() -> None:
         assert "1645" in requested_params[0]
 
         # Cache should only contain the validated params
-        assert "1640" in bsblan._hot_water_param_cache
-        assert "1645" in bsblan._hot_water_param_cache
-        assert "1648" not in bsblan._hot_water_param_cache
+        assert "1640" in bsblan._validator._hot_water_param_cache
+        assert "1645" in bsblan._validator._hot_water_param_cache
+        assert "1648" not in bsblan._validator._hot_water_param_cache
 
 
 @pytest.mark.asyncio
@@ -635,7 +635,7 @@ async def test_ensure_hot_water_group_validated_include_empty_result() -> None:
                 "1640": "legionella_function",
             }
         }
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         request_count = 0
 
@@ -656,7 +656,7 @@ async def test_ensure_hot_water_group_validated_include_empty_result() -> None:
         # No request should be made since no params match
         assert request_count == 0
         # Group should still be marked as validated
-        assert "config" in bsblan._validated_hot_water_groups
+        assert "config" in bsblan._validator._validated_hot_water_groups
 
 
 @pytest.mark.asyncio
@@ -672,7 +672,7 @@ async def test_ensure_hot_water_group_validated_without_include() -> None:
                 "1648": "legionella_circulation_temp_diff",
             }
         }
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         requested_params: list[str] = []
 
@@ -703,6 +703,6 @@ async def test_ensure_hot_water_group_validated_without_include() -> None:
         assert "1648" in requested_params[0]
 
         # All params should be cached
-        assert "1640" in bsblan._hot_water_param_cache
-        assert "1645" in bsblan._hot_water_param_cache
-        assert "1648" in bsblan._hot_water_param_cache
+        assert "1640" in bsblan._validator._hot_water_param_cache
+        assert "1645" in bsblan._validator._hot_water_param_cache
+        assert "1648" in bsblan._validator._hot_water_param_cache

--- a/tests/test_hotwater_state.py
+++ b/tests/test_hotwater_state.py
@@ -50,7 +50,7 @@ async def test_hot_water_state(
 
         api_validator = APIValidator(test_api_v3)
         api_validator.validated_sections.add("hot_water")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Set up the hot water parameter cache with all available parameters
         hot_water_cache = {
@@ -67,7 +67,7 @@ async def test_hot_water_state(
         bsblan.set_hot_water_cache(hot_water_cache)
 
         # Mark essential group as validated to skip validation logic
-        bsblan._validated_hot_water_groups.add("essential")
+        bsblan._validator._validated_hot_water_groups.add("essential")
 
         # Mock the request response to only return requested parameters
         fixture_data: dict[str, Any] = json.loads(load_fixture("hot_water_state.json"))

--- a/tests/test_include_parameter.py
+++ b/tests/test_include_parameter.py
@@ -57,7 +57,7 @@ async def test_section_method_with_include_single_param(
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add(section)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Load appropriate fixture based on method
         fixture_map = {
@@ -111,7 +111,7 @@ async def test_section_method_with_empty_include_list(
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add(section)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock: AsyncMock = AsyncMock()
         monkeypatch.setattr(bsblan, "_request", request_mock)
@@ -151,7 +151,7 @@ async def test_section_method_with_invalid_params(
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add(section)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock: AsyncMock = AsyncMock()
         monkeypatch.setattr(bsblan, "_request", request_mock)
@@ -192,7 +192,7 @@ async def test_validate_api_section_with_include_filter(monkeypatch: Any) -> Non
         bsblan._api_data = api_data  # type: ignore[assignment]
 
         api_validator = APIValidator(api_data)
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Mock request to return only the filtered param
         request_mock = AsyncMock(
@@ -201,7 +201,9 @@ async def test_validate_api_section_with_include_filter(monkeypatch: Any) -> Non
         monkeypatch.setattr(bsblan, "_request", request_mock)
 
         # Validate with include filter - should only request hvac_mode
-        result = await bsblan._validate_api_section("heating", include=["hvac_mode"])
+        result = await bsblan._validator._validate_api_section(
+            "heating", include=["hvac_mode"]
+        )
 
         # Verify only filtered param was requested
         request_mock.assert_awaited_once()
@@ -260,7 +262,7 @@ async def test_state_with_include_multiple_params(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("heating")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         state_data = json.loads(load_fixture("state.json"))
         partial_response = {
@@ -292,7 +294,7 @@ async def test_state_include_skips_temperature_unit_warning(
         monkeypatch.setattr(bsblan, "_firmware_version", "5.1.0")
         monkeypatch.setattr(bsblan, "_api_version", "v3")
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
-        bsblan._api_validator = APIValidator(API_V3)
+        bsblan._validator._api_validator = APIValidator(API_V3)
 
         state_data = json.loads(load_fixture("state.json"))
         partial_response = {"700": state_data["700"]}
@@ -325,7 +327,7 @@ async def test_state_with_include_mixed_valid_invalid_params(monkeypatch: Any) -
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("heating")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         state_data = json.loads(load_fixture("state.json"))
         partial_response = {"700": state_data["700"]}
@@ -359,7 +361,7 @@ async def test_state_without_include(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("heating")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock: AsyncMock = AsyncMock(
             return_value=json.loads(load_fixture("state.json"))
@@ -389,7 +391,7 @@ async def test_static_values_with_include(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("staticValues")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         partial_response = {
             "712": {
@@ -478,8 +480,8 @@ async def test_hot_water_method_with_include(
         monkeypatch.setattr(bsblan, "_api_version", "v3")
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
-        monkeypatch.setattr(bsblan, "_hot_water_param_cache", param_cache)
-        bsblan._validated_hot_water_groups.add(group_name)
+        monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
+        bsblan._validator._validated_hot_water_groups.add(group_name)
 
         # Create mock response
         mock_response = {
@@ -543,8 +545,8 @@ async def test_hot_water_method_with_empty_include_list(
         monkeypatch.setattr(bsblan, "_api_version", "v3")
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
-        monkeypatch.setattr(bsblan, "_hot_water_param_cache", param_cache)
-        bsblan._validated_hot_water_groups.add(group_name)
+        monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
+        bsblan._validator._validated_hot_water_groups.add(group_name)
 
         request_mock: AsyncMock = AsyncMock()
         monkeypatch.setattr(bsblan, "_request", request_mock)
@@ -594,8 +596,8 @@ async def test_hot_water_method_with_invalid_params(
         monkeypatch.setattr(bsblan, "_api_version", "v3")
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
-        monkeypatch.setattr(bsblan, "_hot_water_param_cache", param_cache)
-        bsblan._validated_hot_water_groups.add(group_name)
+        monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
+        bsblan._validator._validated_hot_water_groups.add(group_name)
 
         request_mock: AsyncMock = AsyncMock()
         monkeypatch.setattr(bsblan, "_request", request_mock)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -42,7 +42,7 @@ async def test_info(aresponses: ResponsesMockServer, monkeypatch: Any) -> None:
             "6225": "controller_family",
             "6226": "controller_variant",
         }
-        object.__setattr__(bsblan, "_api_validator", mock_validator)
+        object.__setattr__(bsblan._validator, "_api_validator", mock_validator)
 
         info: Info = await bsblan.info()
         assert info

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -166,7 +166,7 @@ async def test_setup_api_validator() -> None:
 
         await bsblan._setup_api_validator()
 
-        assert bsblan._api_validator is not None
+        assert bsblan._validator._api_validator is not None
         assert bsblan._api_data is not None
 
 

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -40,7 +40,7 @@ async def pps_bsblan() -> AsyncGenerator[BSBLAN, None]:
         )
         bsblan._api_data = build_api_config("v3")
         bsblan._apply_bus_specific_api_config()
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
         yield bsblan
 
 
@@ -329,7 +329,7 @@ async def test_pps_thermostat_rejects_read_only_bus() -> None:
         )
         bsblan._api_data = build_api_config("v3")
         bsblan._apply_bus_specific_api_config()
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
         request_mock = AsyncMock(return_value={"status": "ok"})
         bsblan._request = request_mock  # type: ignore[method-assign]
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -83,7 +83,7 @@ async def test_sensor(
 
         api_validator = APIValidator(api_data)
         api_validator.validated_sections.add("sensor")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock = AsyncMock(return_value=sensor_response)
         monkeypatch.setattr(bsblan, "_request", request_mock)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -33,7 +33,7 @@ async def test_state(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("heating")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         request_mock: AsyncMock = AsyncMock(
             return_value=json.loads(load_fixture("state.json")),
@@ -104,7 +104,7 @@ async def test_state_with_cooling_include(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("heating")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         state_data = json.loads(load_fixture("state.json"))
         request_mock: AsyncMock = AsyncMock(return_value={"902": state_data["902"]})
@@ -132,7 +132,7 @@ async def test_state_without_cooling_strips_target_temperature_high(
         bsblan._api_data = {
             section: params.copy() for section, params in API_V3.items()
         }
-        bsblan._api_validator = APIValidator(bsblan._api_data)
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
         state_data = json.loads(load_fixture("state.json"))
         validation_response = {"700": state_data["700"]}

--- a/tests/test_static_state.py
+++ b/tests/test_static_state.py
@@ -30,7 +30,7 @@ async def test_sensor(monkeypatch: Any) -> None:
 
         api_validator = APIValidator(API_V3)
         api_validator.validated_sections.add("staticValues")
-        bsblan._api_validator = api_validator
+        bsblan._validator._api_validator = api_validator
 
         # Mock the request response
         request_mock = AsyncMock(

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -150,7 +150,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
                 for section, params in source_config.items()
             },
         )
-        client._api_validator = APIValidator(client._api_data)
+        client._validator._api_validator = APIValidator(client._api_data)
 
         # Mock static_values to return data without min_temp
         # Mock static_values without protective or pps min temp
@@ -187,7 +187,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
                 for section, params in source_config.items()
             },
         )
-        client._api_validator = APIValidator(client._api_data)
+        client._validator._api_validator = APIValidator(client._api_data)
 
         # Mock static_values to return data without max_temp
         static_values_mock = AsyncMock()
@@ -223,7 +223,7 @@ async def test_temperature_range_static_values_error(monkeypatch: Any) -> None:
                 for section, params in source_config.items()
             },
         )
-        client._api_validator = APIValidator(client._api_data)
+        client._validator._api_validator = APIValidator(client._api_data)
 
         # Mock static_values to raise an error
         static_values_mock = AsyncMock(side_effect=BSBLANError("Test error"))


### PR DESCRIPTION
This pull request refactors the API validation logic in the `BSBLAN` class to delegate all validation-related functionality to a new `SectionValidator` class. This change centralizes and simplifies validation, reduces code duplication, and improves maintainability. The tests are updated accordingly to interact with the new validator structure.

Key changes include:

**Refactoring and code structure:**

* All API validation logic and hot water parameter caching are moved from the `BSBLAN` class to the new `SectionValidator` class, removing duplicated state and methods from `BSBLAN`. (`src/bsblan/bsblan.py`, [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L110-R117) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L250-R260) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L316-R279) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L372-R324) [[5]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L575-R368) [[6]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1000-R792) [[7]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1466-R1258)
* The `BSBLAN` class now initializes and delegates all validation and cache management to the `SectionValidator` instance. (`src/bsblan/bsblan.py`, [src/bsblan/bsblan.pyR127-R137](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R127-R137))

**Testing updates:**

* All tests in `tests/test_api_validation.py` are updated to use the new `SectionValidator` interface, accessing the underlying validator through `bsblan._validator._api_validator` and calling validation methods via the validator. (`tests/test_api_validation.py`, [[1]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L70-R76) [[2]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L86-R89) [[3]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L99-R103) [[4]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L113-R119) [[5]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L161-R162) [[6]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L184-R186) [[7]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L208-R208) [[8]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L217-R221) [[9]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L242-R250)

**Code cleanup:**

* Removes unused imports and redundant fields related to validation and hot water parameter caching from `BSBLAN`. (`src/bsblan/bsblan.py`, [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L5-L23) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L57-R55) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L110-R117)

This refactor improves separation of concerns and makes the validation logic easier to test and maintain.