### PR TITLE
refactor: extract TemperatureManager collaborator

### DIFF
--- a/src/bsblan/_temperature.py
+++ b/src/bsblan/_temperature.py
@@ -1,0 +1,324 @@
+"""Temperature range, unit, and bounds management for the BSBLAN client.
+
+Owns the per-circuit temperature range cache, the set of circuits whose range
+has been initialized, and the active temperature unit. Ranges are lazily
+fetched from the device static values and target temperatures are validated
+against the heating and cooling bounds. The owning client keeps thin
+delegations that forward here.
+
+The manager reads discovered circuits and fetches static values through
+callables supplied by the owning client so it does not hold a back-reference
+to the facade.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .exceptions import BSBLANError, BSBLANInvalidParameterError
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from typing import Any
+
+    from .bsblan import SectionLiteral
+    from .models import StaticState
+
+logger = logging.getLogger(__name__)
+
+
+class TemperatureManager:
+    """Manage per-circuit temperature ranges, the unit, and bounds checks.
+
+    The manager owns the temperature state (per-circuit range cache, the set of
+    circuits whose range has been initialized, and the active unit). Static
+    values are read through ``static_values`` and discovered circuits through
+    ``get_available_circuits`` so the manager never holds a back-reference to
+    the owning client.
+    """
+
+    def __init__(
+        self,
+        *,
+        static_values: Callable[..., Awaitable[StaticState]],
+        get_available_circuits: Callable[[], set[int] | None],
+    ) -> None:
+        """Initialize the manager with the client's collaborators.
+
+        Args:
+            static_values: Callable returning the static values model for a
+                circuit.
+            get_available_circuits: Callable returning the set of circuits known
+                to be available, or ``None`` when discovery has not run.
+
+        """
+        self._static_values = static_values
+        self._get_available_circuits = get_available_circuits
+        self._temperature_unit: str = "°C"
+        # Per-circuit temperature ranges: circuit_number -> range dict.
+        self._circuit_temp_ranges: dict[int, dict[str, float | None]] = {}
+        self._circuit_temp_initialized: set[int] = set()
+
+    @property
+    def unit(self) -> str:
+        """Return the active temperature unit (°C or °F)."""
+        return self._temperature_unit
+
+    def should_extract_temperature_unit(
+        self,
+        section: SectionLiteral,
+        include: list[str] | None,
+        response_data: dict[str, Any],
+    ) -> bool:
+        """Return whether the validation response should update temperature unit."""
+        if section != "heating":
+            return False
+
+        if include is None or "target_temperature" in include:
+            return True
+
+        return any(param_id in response_data for param_id in ("710", "15004"))
+
+    def extract_temperature_unit_from_response(
+        self, response_data: dict[str, Any]
+    ) -> None:
+        """Extract temperature unit from heating section response data.
+
+        Gets the unit from the target_temperature parameter, which is always
+        present in the heating section.
+
+        Args:
+            response_data: The response data from heating section validation
+
+        """
+        # Look for target_temperature in the response.
+        for param_id, param_data in response_data.items():
+            if param_id in {"710", "15004"} and isinstance(param_data, dict):
+                unit = param_data.get("unit", "")
+                if unit in ("&deg;C", "°C"):
+                    self._temperature_unit = "°C"
+                elif unit == "°F":
+                    self._temperature_unit = "°F"
+                else:
+                    # Keep default if unit is empty or unknown
+                    logger.debug(
+                        "Unknown or empty temperature unit from heating target: "
+                        "'%s'. Using default (°C)",
+                        unit,
+                    )
+                logger.debug("Temperature unit set to: %s", self._temperature_unit)
+                return
+
+        logger.warning(
+            "Could not find target temperature in heating section response. "
+            "Using default temperature unit (°C)"
+        )
+
+    async def _fetch_temperature_range(
+        self,
+        circuit: int,
+    ) -> dict[str, float | None]:
+        """Fetch min/max temperature range for a circuit from the device.
+
+        Args:
+            circuit: The heating circuit number (1 or 2).
+
+        Returns:
+            dict with heating and cooling min/max keys. Values may be None if
+            unavailable.
+
+        """
+        temp_range: dict[str, float | None] = {
+            "min": None,
+            "max": None,
+            "cooling_min": None,
+            "cooling_max": None,
+        }
+        available_circuits = self._get_available_circuits()
+        if available_circuits is not None and circuit not in available_circuits:
+            logger.debug(
+                "Skipping temperature range fetch for unavailable circuit %d",
+                circuit,
+            )
+            return temp_range
+
+        try:
+            static_values = await self._static_values(circuit=circuit)
+        except BSBLANError as err:
+            logger.warning(
+                "Failed to get static values for circuit %d: %s. "
+                "Temperature range will be None",
+                circuit,
+                str(err),
+            )
+            return temp_range
+
+        # Prefer heating_protective_setpoint (714/1014) as the true lower bound
+        # for standard circuits. Fall back to min_temp for PPS circuits (15006)
+        # which have no separate protective setpoint. Skip sources whose value is
+        # inactive (BSB-LAN may return "---" which becomes value=None).
+        min_source = next(
+            (
+                source
+                for source in (
+                    static_values.heating_protective_setpoint,
+                    static_values.min_temp,
+                )
+                if source is not None and source.value is not None
+            ),
+            None,
+        )
+        if min_source is not None:
+            temp_range["min"] = min_source.value
+            logger.debug(
+                "Circuit %d min temp initialized: %s",
+                circuit,
+                temp_range["min"],
+            )
+
+        # Prefer comfort_setpoint_max (716/1016) as the upper bound for standard
+        # circuits. Fall back to max_temp for PPS circuits (15007) which expose
+        # only a generic max. Skip sources whose value is inactive.
+        max_source = next(
+            (
+                source
+                for source in (
+                    static_values.comfort_setpoint_max,
+                    static_values.max_temp,
+                )
+                if source is not None and source.value is not None
+            ),
+            None,
+        )
+        if max_source is not None:
+            temp_range["max"] = max_source.value
+            logger.debug(
+                "Circuit %d max temp initialized: %s",
+                circuit,
+                temp_range["max"],
+            )
+
+        if static_values.cooling_comfort_setpoint_min is not None:
+            temp_range["cooling_min"] = static_values.cooling_comfort_setpoint_min.value
+            logger.debug(
+                "Circuit %d cooling min temp initialized: %s",
+                circuit,
+                temp_range["cooling_min"],
+            )
+
+        if static_values.cooling_reduced_setpoint is not None:
+            temp_range["cooling_max"] = static_values.cooling_reduced_setpoint.value
+            logger.debug(
+                "Circuit %d cooling max temp initialized: %s",
+                circuit,
+                temp_range["cooling_max"],
+            )
+
+        return temp_range
+
+    async def initialize_temperature_range(
+        self,
+        circuit: int = 1,
+    ) -> None:
+        """Initialize the temperature range from static values (lazy loaded).
+
+        This method is called on-demand when temperature range is needed.
+        It uses lazy loading through static_values() which will validate
+        the staticValues section if not already done.
+
+        Args:
+            circuit: The heating circuit number (1 or 2).
+
+        Note: Temperature unit is extracted during heating section validation,
+        so no extra API call is needed here.
+
+        """
+        if circuit in self._circuit_temp_initialized:
+            return
+
+        temp_range = await self._fetch_temperature_range(circuit)
+        self._circuit_temp_ranges[circuit] = temp_range
+        self._circuit_temp_initialized.add(circuit)
+
+    async def _validate_in_range(
+        self,
+        value: str | float,
+        circuit: int,
+        *,
+        min_key: str,
+        max_key: str,
+    ) -> None:
+        """Validate a temperature value against a circuit's configured bounds.
+
+        Lazy-loads the circuit temperature range when needed. If the device
+        does not expose the relevant bounds, only the float conversion is
+        validated.
+
+        Args:
+            value (str | float): The temperature value to validate.
+            circuit (int): The heating circuit number (1 or 2).
+            min_key (str): Range key holding the lower bound.
+            max_key (str): Range key holding the upper bound.
+
+        Raises:
+            BSBLANInvalidParameterError: If the value is not a valid float or
+                falls outside the configured bounds.
+
+        """
+        try:
+            temp = float(value)
+        except ValueError as err:
+            raise BSBLANInvalidParameterError(str(value)) from err
+
+        if circuit not in self._circuit_temp_initialized:
+            await self.initialize_temperature_range(circuit)
+
+        temp_range = self._circuit_temp_ranges.get(circuit, {})
+        min_temp = temp_range.get(min_key)
+        max_temp = temp_range.get(max_key)
+
+        if min_temp is None or max_temp is None:
+            return
+
+        if not (min_temp <= temp <= max_temp):
+            raise BSBLANInvalidParameterError(str(value))
+
+    async def validate_target_temperature_high(
+        self,
+        target_temperature_high: str | float,
+        circuit: int = 1,
+    ) -> None:
+        """Validate the cooling target temperature value."""
+        await self._validate_in_range(
+            target_temperature_high,
+            circuit,
+            min_key="cooling_min",
+            max_key="cooling_max",
+        )
+
+    async def validate_target_temperature(
+        self,
+        target_temperature: str,
+        circuit: int = 1,
+    ) -> None:
+        """Validate the target temperature.
+
+        This method lazy-loads the temperature range if not already initialized.
+        If the device does not provide min/max temperature parameters,
+        only validates that the value is a valid float.
+
+        Args:
+            target_temperature (str): The target temperature to validate.
+            circuit: The heating circuit number (1 or 2).
+
+        Raises:
+            BSBLANInvalidParameterError: If the target temperature is invalid.
+
+        """
+        await self._validate_in_range(
+            target_temperature,
+            circuit,
+            min_key="min",
+            max_key="max",
+        )

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 import aiohttp
 from aiohttp.hdrs import METH_POST
 
+from ._temperature import TemperatureManager
 from ._transport import BSBLANTransport
 from ._validation import SectionValidator
 from ._version import VersionResolver
@@ -105,15 +106,10 @@ class BSBLAN:
     _api_data: APIConfig | None = None
     _device: Device | None = None
     _initialized: bool = False
-    _temperature_unit: str = "°C"
-    # Per-circuit temperature ranges: circuit_number -> {min, max}
-    _circuit_temp_ranges: dict[int, dict[str, float | None]] = field(
-        default_factory=dict,
-    )
-    _circuit_temp_initialized: set[int] = field(default_factory=set)
     _available_circuits: set[int] | None = None
     _transport: BSBLANTransport = field(init=False)
     _version_resolver: VersionResolver = field(init=False)
+    _temperature: TemperatureManager = field(init=False)
     _validator: SectionValidator = field(init=False)
 
     def __post_init__(self) -> None:
@@ -124,6 +120,10 @@ class BSBLAN:
             lambda: self._firmware_version,
         )
         self._version_resolver = VersionResolver()
+        self._temperature = TemperatureManager(
+            static_values=lambda **kw: self.static_values(**kw),  # noqa: PLW0108
+            get_available_circuits=lambda: self._available_circuits,
+        )
         # _request and _extract_params_summary are monkeypatched by some tests,
         # so resolve them lazily instead of binding them at construction time.
         self._validator = SectionValidator(
@@ -285,13 +285,9 @@ class BSBLAN:
         response_data: dict[str, Any],
     ) -> bool:
         """Return whether the validation response should update temperature unit."""
-        if section != "heating":
-            return False
-
-        if include is None or "target_temperature" in include:
-            return True
-
-        return any(param_id in response_data for param_id in ("710", "15004"))
+        return self._temperature.should_extract_temperature_unit(
+            section, include, response_data
+        )
 
     async def _ensure_hot_water_group_validated(
         self,
@@ -335,28 +331,7 @@ class BSBLAN:
             response_data: The response data from heating section validation
 
         """
-        # Look for target_temperature in the response.
-        for param_id, param_data in response_data.items():
-            if param_id in {"710", "15004"} and isinstance(param_data, dict):
-                unit = param_data.get("unit", "")
-                if unit in ("&deg;C", "°C"):
-                    self._temperature_unit = "°C"
-                elif unit == "°F":
-                    self._temperature_unit = "°F"
-                else:
-                    # Keep default if unit is empty or unknown
-                    logger.debug(
-                        "Unknown or empty temperature unit from heating target: "
-                        "'%s'. Using default (°C)",
-                        unit,
-                    )
-                logger.debug("Temperature unit set to: %s", self._temperature_unit)
-                return
-
-        logger.warning(
-            "Could not find target temperature in heating section response. "
-            "Using default temperature unit (°C)"
-        )
+        self._temperature.extract_temperature_unit_from_response(response_data)
 
     def set_hot_water_cache(self, params: dict[str, str]) -> None:
         """Set the hot water parameter cache manually (for testing).
@@ -460,110 +435,6 @@ class BSBLAN:
             firmware_version=self._firmware_version,
         )
 
-    async def _fetch_temperature_range(
-        self,
-        circuit: int,
-    ) -> dict[str, float | None]:
-        """Fetch min/max temperature range for a circuit from the device.
-
-        Args:
-            circuit: The heating circuit number (1 or 2).
-
-        Returns:
-            dict with heating and cooling min/max keys. Values may be None if
-            unavailable.
-
-        """
-        temp_range: dict[str, float | None] = {
-            "min": None,
-            "max": None,
-            "cooling_min": None,
-            "cooling_max": None,
-        }
-        if (
-            self._available_circuits is not None
-            and circuit not in self._available_circuits
-        ):
-            logger.debug(
-                "Skipping temperature range fetch for unavailable circuit %d",
-                circuit,
-            )
-            return temp_range
-
-        try:
-            static_values = await self.static_values(circuit=circuit)
-        except BSBLANError as err:
-            logger.warning(
-                "Failed to get static values for circuit %d: %s. "
-                "Temperature range will be None",
-                circuit,
-                str(err),
-            )
-            return temp_range
-
-        # Prefer heating_protective_setpoint (714/1014) as the true lower bound
-        # for standard circuits. Fall back to min_temp for PPS circuits (15006)
-        # which have no separate protective setpoint. Skip sources whose value is
-        # inactive (BSB-LAN may return "---" which becomes value=None).
-        min_source = next(
-            (
-                source
-                for source in (
-                    static_values.heating_protective_setpoint,
-                    static_values.min_temp,
-                )
-                if source is not None and source.value is not None
-            ),
-            None,
-        )
-        if min_source is not None:
-            temp_range["min"] = min_source.value
-            logger.debug(
-                "Circuit %d min temp initialized: %s",
-                circuit,
-                temp_range["min"],
-            )
-
-        # Prefer comfort_setpoint_max (716/1016) as the upper bound for standard
-        # circuits. Fall back to max_temp for PPS circuits (15007) which expose
-        # only a generic max. Skip sources whose value is inactive.
-        max_source = next(
-            (
-                source
-                for source in (
-                    static_values.comfort_setpoint_max,
-                    static_values.max_temp,
-                )
-                if source is not None and source.value is not None
-            ),
-            None,
-        )
-        if max_source is not None:
-            temp_range["max"] = max_source.value
-            logger.debug(
-                "Circuit %d max temp initialized: %s",
-                circuit,
-                temp_range["max"],
-            )
-
-        if static_values.cooling_comfort_setpoint_min is not None:
-            temp_range["cooling_min"] = static_values.cooling_comfort_setpoint_min.value
-            logger.debug(
-                "Circuit %d cooling min temp initialized: %s",
-                circuit,
-                temp_range["cooling_min"],
-            )
-
-        if static_values.cooling_reduced_setpoint is not None:
-            temp_range["cooling_max"] = static_values.cooling_reduced_setpoint.value
-            logger.debug(
-                "Circuit %d cooling max temp initialized: %s",
-                circuit,
-                temp_range["cooling_max"],
-            )
-
-        return temp_range
-
     async def _initialize_temperature_range(
         self,
         circuit: int = 1,
@@ -581,12 +452,7 @@ class BSBLAN:
         so no extra API call is needed here.
 
         """
-        if circuit in self._circuit_temp_initialized:
-            return
-
-        temp_range = await self._fetch_temperature_range(circuit)
-        self._circuit_temp_ranges[circuit] = temp_range
-        self._circuit_temp_initialized.add(circuit)
+        await self._temperature.initialize_temperature_range(circuit)
 
     def _validate_circuit(self, circuit: int) -> None:
         """Validate the circuit number.
@@ -624,7 +490,7 @@ class BSBLAN:
             initialization, it will return the default unit (°C).
 
         """
-        return self._temperature_unit
+        return self._temperature.unit
 
     def _copy_api_config(self) -> APIConfig:
         """Create a copy of the API configuration for the current version.
@@ -1077,60 +943,15 @@ class BSBLAN:
             return {"target_temperature": "15004", "hvac_mode": "15000"}
         return CircuitConfig.THERMOSTAT_PARAMS[circuit]
 
-    async def _validate_temperature_in_range(
-        self,
-        value: str | float,
-        circuit: int,
-        *,
-        min_key: str,
-        max_key: str,
-    ) -> None:
-        """Validate a temperature value against a circuit's configured bounds.
-
-        Lazy-loads the circuit temperature range when needed. If the device
-        does not expose the relevant bounds, only the float conversion is
-        validated.
-
-        Args:
-            value (str | float): The temperature value to validate.
-            circuit (int): The heating circuit number (1 or 2).
-            min_key (str): Range key holding the lower bound.
-            max_key (str): Range key holding the upper bound.
-
-        Raises:
-            BSBLANInvalidParameterError: If the value is not a valid float or
-                falls outside the configured bounds.
-
-        """
-        try:
-            temp = float(value)
-        except ValueError as err:
-            raise BSBLANInvalidParameterError(str(value)) from err
-
-        if circuit not in self._circuit_temp_initialized:
-            await self._initialize_temperature_range(circuit)
-
-        temp_range = self._circuit_temp_ranges.get(circuit, {})
-        min_temp = temp_range.get(min_key)
-        max_temp = temp_range.get(max_key)
-
-        if min_temp is None or max_temp is None:
-            return
-
-        if not (min_temp <= temp <= max_temp):
-            raise BSBLANInvalidParameterError(str(value))
-
     async def _validate_target_temperature_high(
         self,
         target_temperature_high: str | float,
         circuit: int = 1,
     ) -> None:
         """Validate the cooling target temperature value."""
-        await self._validate_temperature_in_range(
+        await self._temperature.validate_target_temperature_high(
             target_temperature_high,
             circuit,
-            min_key="cooling_min",
-            max_key="cooling_max",
         )
 
     async def _validate_target_temperature(
@@ -1152,11 +973,9 @@ class BSBLAN:
             BSBLANInvalidParameterError: If the target temperature is invalid.
 
         """
-        await self._validate_temperature_in_range(
+        await self._temperature.validate_target_temperature(
             target_temperature,
             circuit,
-            min_key="min",
-            max_key="max",
         )
 
     def _validate_hvac_mode(self, hvac_mode: int) -> None:

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -413,7 +413,7 @@ async def test_ensure_section_validated_heating_extracts_temp_unit() -> None:
         await bsblan._ensure_section_validated("heating")
 
         # Temperature unit should be extracted from heating response
-        assert bsblan._temperature_unit == "°F"
+        assert bsblan._temperature._temperature_unit == "°F"
 
 
 @pytest.mark.asyncio

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -36,8 +36,8 @@ async def mock_bsblan_circuit() -> AsyncGenerator[BSBLAN, None]:
         bsblan._firmware_version = "1.0.38-20200730234859"
         bsblan._api_version = "v3"
         bsblan._api_data = build_api_config("v3")
-        bsblan._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
-        bsblan._circuit_temp_initialized.add(1)
+        bsblan._temperature._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
+        bsblan._temperature._circuit_temp_initialized.add(1)
 
         api_validator = APIValidator(bsblan._api_data)
         api_validator.validated_sections.add("heating")
@@ -247,11 +247,11 @@ async def test_thermostat_circuit2_temperature(
 ) -> None:
     """Test setting temperature on circuit 2."""
     # Set up HC2 temp range
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "min": 16.0,
         "max": 28.0,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     expected_data = {
         "Parameter": "1010",
@@ -277,11 +277,11 @@ async def test_thermostat_circuit2_hvac_mode(
 ) -> None:
     """Test setting HVAC mode on circuit 2."""
     # Set up HC2 temp range
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "min": 16.0,
         "max": 28.0,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     expected_data = {
         "Parameter": "1000",
@@ -322,11 +322,11 @@ async def test_thermostat_circuit2_invalid_temperature(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:
     """Test setting out-of-range temperature on circuit 2."""
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "min": 16.0,
         "max": 28.0,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     with pytest.raises(BSBLANInvalidParameterError):
         await mock_bsblan_circuit.thermostat(
@@ -341,11 +341,11 @@ async def test_thermostat_circuit2_no_temp_range(
 ) -> None:
     """Test thermostat passes through when HC2 temp range not available."""
     # Set HC2 as initialized but with None range
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "min": None,
         "max": None,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     # Should pass through without range validation when min/max are None
     mock_bsblan_circuit._request = AsyncMock(return_value={"status": "success"})
@@ -394,11 +394,11 @@ async def test_thermostat_circuit2_no_params(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:
     """Test that multi-parameter error still works with circuit."""
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "min": 16.0,
         "max": 28.0,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     with pytest.raises(BSBLANError) as exc_info:
         await mock_bsblan_circuit.thermostat(circuit=2)
@@ -411,13 +411,13 @@ async def test_thermostat_circuit2_cooling_temperature(
     aresponses: ResponsesMockServer,
 ) -> None:
     """Test setting cooling temperature on circuit 2."""
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "min": 16.0,
         "max": 28.0,
         "cooling_min": 18.0,
         "cooling_max": 26.0,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     expected_data = {
         "Parameter": "1202",
@@ -441,11 +441,11 @@ async def test_thermostat_circuit2_invalid_cooling_temperature(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:
     """Test setting out-of-range cooling temperature on circuit 2."""
-    mock_bsblan_circuit._circuit_temp_ranges[2] = {
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
         "cooling_min": 18.0,
         "cooling_max": 26.0,
     }
-    mock_bsblan_circuit._circuit_temp_initialized.add(2)
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
 
     with pytest.raises(BSBLANInvalidParameterError):
         await mock_bsblan_circuit.thermostat(
@@ -489,11 +489,11 @@ async def test_circuit2_temp_range_initialization(
 
         await bsblan._initialize_temperature_range(circuit=2)
 
-        assert 2 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[2]["min"] == 8.0
-        assert bsblan._circuit_temp_ranges[2]["max"] == 28.0
-        assert bsblan._circuit_temp_ranges[2]["cooling_min"] == 18.0
-        assert bsblan._circuit_temp_ranges[2]["cooling_max"] == 26.0
+        assert 2 in bsblan._temperature._circuit_temp_initialized
+        assert bsblan._temperature._circuit_temp_ranges[2]["min"] == 8.0
+        assert bsblan._temperature._circuit_temp_ranges[2]["max"] == 28.0
+        assert bsblan._temperature._circuit_temp_ranges[2]["cooling_min"] == 18.0
+        assert bsblan._temperature._circuit_temp_ranges[2]["cooling_max"] == 26.0
 
 
 @pytest.mark.asyncio
@@ -525,11 +525,11 @@ async def test_circuit1_temp_range_uses_protective_lower_bound(
 
         await bsblan._initialize_temperature_range(circuit=1)
 
-        assert 1 in bsblan._circuit_temp_initialized
+        assert 1 in bsblan._temperature._circuit_temp_initialized
         # Lower bound is the protective/frost setpoint (714 = 8.0), not the
         # reduced setpoint (712 = 17.0).
-        assert bsblan._circuit_temp_ranges[1]["min"] == 8.0
-        assert bsblan._circuit_temp_ranges[1]["max"] == 23.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["min"] == 8.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["max"] == 23.0
 
         with pytest.raises(BSBLANInvalidParameterError):
             await bsblan._validate_target_temperature("7.5", circuit=1)
@@ -579,15 +579,15 @@ async def test_thermostat_circuit2_lazy_temp_init(
         monkeypatch.setattr(bsblan, "_request", mock_request)
 
         # HC2 temp range is NOT initialized yet
-        assert 2 not in bsblan._circuit_temp_initialized
+        assert 2 not in bsblan._temperature._circuit_temp_initialized
 
         # This should trigger lazy init of HC2 temp range
         await bsblan._validate_target_temperature("20.0", circuit=2)
 
         # Verify it was initialized
-        assert 2 in bsblan._circuit_temp_initialized
-        assert bsblan._circuit_temp_ranges[2]["min"] == 8.0
-        assert bsblan._circuit_temp_ranges[2]["max"] == 28.0
+        assert 2 in bsblan._temperature._circuit_temp_initialized
+        assert bsblan._temperature._circuit_temp_ranges[2]["min"] == 8.0
+        assert bsblan._temperature._circuit_temp_ranges[2]["max"] == 28.0
 
 
 # --- Tests for get_available_circuits ---
@@ -781,8 +781,8 @@ async def test_temperature_range_skips_unavailable_discovered_circuit(
 
     await bsblan._initialize_temperature_range(circuit=2)
 
-    assert 2 in bsblan._circuit_temp_initialized
-    assert bsblan._circuit_temp_ranges[2] == {
+    assert 2 in bsblan._temperature._circuit_temp_initialized
+    assert bsblan._temperature._circuit_temp_ranges[2] == {
         "min": None,
         "max": None,
         "cooling_min": None,

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -249,8 +249,8 @@ async def test_pps_thermostat_hvac_mode_writes_translated_value(
     expected_value: str,
 ) -> None:
     """Test PPS mode writes translate library modes to PPS raw values."""
-    pps_bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
-    pps_bsblan._circuit_temp_initialized.add(1)
+    pps_bsblan._temperature._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+    pps_bsblan._temperature._circuit_temp_initialized.add(1)
     request_mock = AsyncMock(return_value={"status": "ok"})
     pps_bsblan._request = request_mock  # type: ignore[method-assign]
 
@@ -267,8 +267,8 @@ async def test_pps_thermostat_temperature_writes_comfort_setpoint(
     pps_bsblan: BSBLAN,
 ) -> None:
     """Test PPS target temperature writes use comfort setpoint."""
-    pps_bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
-    pps_bsblan._circuit_temp_initialized.add(1)
+    pps_bsblan._temperature._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+    pps_bsblan._temperature._circuit_temp_initialized.add(1)
     request_mock = AsyncMock(return_value={"status": "ok"})
     pps_bsblan._request = request_mock  # type: ignore[method-assign]
 
@@ -285,8 +285,8 @@ async def test_pps_thermostat_rejects_cooling_temperature(
     pps_bsblan: BSBLAN,
 ) -> None:
     """Test PPS climate rejects cooling target writes."""
-    pps_bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
-    pps_bsblan._circuit_temp_initialized.add(1)
+    pps_bsblan._temperature._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+    pps_bsblan._temperature._circuit_temp_initialized.add(1)
     request_mock = AsyncMock(return_value={"status": "ok"})
     pps_bsblan._request = request_mock  # type: ignore[method-assign]
 
@@ -301,8 +301,8 @@ async def test_pps_thermostat_rejects_unsupported_eco_mode(
     pps_bsblan: BSBLAN,
 ) -> None:
     """Test PPS climate rejects the library eco mode value."""
-    pps_bsblan._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
-    pps_bsblan._circuit_temp_initialized.add(1)
+    pps_bsblan._temperature._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+    pps_bsblan._temperature._circuit_temp_initialized.add(1)
     request_mock = AsyncMock(return_value={"status": "ok"})
     pps_bsblan._request = request_mock  # type: ignore[method-assign]
 

--- a/tests/test_temperature_unit.py
+++ b/tests/test_temperature_unit.py
@@ -20,7 +20,7 @@ async def test_temperature_unit_getter() -> None:
     assert bsblan.get_temperature_unit == "°C"
 
     # Test with custom unit set
-    bsblan._temperature_unit = "°F"
+    bsblan._temperature._temperature_unit = "°F"
     assert bsblan.get_temperature_unit == "°F"
 
 
@@ -41,11 +41,11 @@ async def test_initialize_temperature_range_celsius() -> None:
         await bsblan._initialize_temperature_range()
 
         # Verify temperature range was set correctly
-        assert bsblan._circuit_temp_ranges[1]["min"] == 10.0
-        assert bsblan._circuit_temp_ranges[1]["max"] == 30.0
-        assert bsblan._circuit_temp_ranges[1]["cooling_min"] is None
-        assert bsblan._circuit_temp_ranges[1]["cooling_max"] is None
-        assert 1 in bsblan._circuit_temp_initialized
+        assert bsblan._temperature._circuit_temp_ranges[1]["min"] == 10.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["max"] == 30.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["cooling_min"] is None
+        assert bsblan._temperature._circuit_temp_ranges[1]["cooling_max"] is None
+        assert 1 in bsblan._temperature._circuit_temp_initialized
 
 
 @pytest.mark.asyncio
@@ -65,11 +65,11 @@ async def test_initialize_temperature_range_fahrenheit() -> None:
         await bsblan._initialize_temperature_range()
 
         # Verify temperature range was set correctly
-        assert bsblan._circuit_temp_ranges[1]["min"] == 50.0
-        assert bsblan._circuit_temp_ranges[1]["max"] == 86.0
-        assert bsblan._circuit_temp_ranges[1]["cooling_min"] is None
-        assert bsblan._circuit_temp_ranges[1]["cooling_max"] is None
-        assert 1 in bsblan._circuit_temp_initialized
+        assert bsblan._temperature._circuit_temp_ranges[1]["min"] == 50.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["max"] == 86.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["cooling_min"] is None
+        assert bsblan._temperature._circuit_temp_ranges[1]["cooling_max"] is None
+        assert 1 in bsblan._temperature._circuit_temp_initialized
 
 
 @pytest.mark.asyncio
@@ -96,11 +96,11 @@ async def test_initialize_temperature_range_alternate_celsius_format() -> None:
         await bsblan._initialize_temperature_range()
 
         # Verify temperature range was set correctly
-        assert bsblan._circuit_temp_ranges[1]["min"] == 10.0
-        assert bsblan._circuit_temp_ranges[1]["max"] == 30.0
-        assert bsblan._circuit_temp_ranges[1]["cooling_min"] is None
-        assert bsblan._circuit_temp_ranges[1]["cooling_max"] is None
-        assert 1 in bsblan._circuit_temp_initialized
+        assert bsblan._temperature._circuit_temp_ranges[1]["min"] == 10.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["max"] == 30.0
+        assert bsblan._temperature._circuit_temp_ranges[1]["cooling_min"] is None
+        assert bsblan._temperature._circuit_temp_ranges[1]["cooling_max"] is None
+        assert 1 in bsblan._temperature._circuit_temp_initialized
 
 
 @pytest.mark.asyncio
@@ -117,7 +117,7 @@ async def test_extract_temperature_unit_from_response_celsius() -> None:
 
     bsblan._extract_temperature_unit_from_response(response_data)
 
-    assert bsblan._temperature_unit == "°C"
+    assert bsblan._temperature._temperature_unit == "°C"
 
 
 @pytest.mark.asyncio
@@ -134,7 +134,7 @@ async def test_extract_temperature_unit_from_response_fahrenheit() -> None:
 
     bsblan._extract_temperature_unit_from_response(response_data)
 
-    assert bsblan._temperature_unit == "°F"
+    assert bsblan._temperature._temperature_unit == "°F"
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_extract_temperature_unit_from_response_html_entity() -> None:
 
     bsblan._extract_temperature_unit_from_response(response_data)
 
-    assert bsblan._temperature_unit == "°C"
+    assert bsblan._temperature._temperature_unit == "°C"
 
 
 @pytest.mark.asyncio
@@ -160,7 +160,7 @@ async def test_extract_temperature_unit_from_response_missing_param() -> None:
     bsblan = BSBLAN(config)
 
     # Set to Fahrenheit first to verify it stays as default when param is missing
-    bsblan._temperature_unit = "°F"
+    bsblan._temperature._temperature_unit = "°F"
 
     # Mock response data without parameter 710
     response_data = {
@@ -170,7 +170,7 @@ async def test_extract_temperature_unit_from_response_missing_param() -> None:
     bsblan._extract_temperature_unit_from_response(response_data)
 
     # Should keep the existing value when param 710 is not found
-    assert bsblan._temperature_unit == "°F"
+    assert bsblan._temperature._temperature_unit == "°F"
 
 
 @pytest.mark.asyncio
@@ -192,7 +192,7 @@ async def test_extract_temperature_unit_unknown_unit() -> None:
     bsblan._extract_temperature_unit_from_response(response_data)
 
     # Should keep default
-    assert bsblan._temperature_unit == "°C"
+    assert bsblan._temperature._temperature_unit == "°C"
 
 
 @pytest.mark.asyncio
@@ -214,4 +214,4 @@ async def test_extract_temperature_unit_empty_unit() -> None:
     bsblan._extract_temperature_unit_from_response(response_data)
 
     # Should keep default
-    assert bsblan._temperature_unit == "°C"
+    assert bsblan._temperature._temperature_unit == "°C"

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -24,7 +24,7 @@ async def test_validate_target_temperature_no_range() -> None:
     async def mock_init_temp_range(circuit: int = 1) -> None:
         pass
 
-    bsblan._initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
+    bsblan._temperature.initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
 
     # Should pass through without error when min/max are not available
     await bsblan._validate_target_temperature("22.0")
@@ -37,8 +37,8 @@ async def test_validate_target_temperature_invalid_value() -> None:
     bsblan = BSBLAN(config)
 
     # Initialize temperature range
-    bsblan._circuit_temp_ranges[1] = {"min": 10.0, "max": 30.0}
-    bsblan._circuit_temp_initialized.add(1)
+    bsblan._temperature._circuit_temp_ranges[1] = {"min": 10.0, "max": 30.0}
+    bsblan._temperature._circuit_temp_initialized.add(1)
 
     # Test with non-numeric value
     with pytest.raises(BSBLANInvalidParameterError):
@@ -52,8 +52,8 @@ async def test_validate_target_temperature_out_of_range() -> None:
     bsblan = BSBLAN(config)
 
     # Initialize temperature range
-    bsblan._circuit_temp_ranges[1] = {"min": 10.0, "max": 30.0}
-    bsblan._circuit_temp_initialized.add(1)
+    bsblan._temperature._circuit_temp_ranges[1] = {"min": 10.0, "max": 30.0}
+    bsblan._temperature._circuit_temp_initialized.add(1)
 
     # Test with value below minimum
     with pytest.raises(BSBLANInvalidParameterError):
@@ -71,8 +71,8 @@ async def test_validate_target_temperature_valid() -> None:
     bsblan = BSBLAN(config)
 
     # Initialize temperature range
-    bsblan._circuit_temp_ranges[1] = {"min": 10.0, "max": 30.0}
-    bsblan._circuit_temp_initialized.add(1)
+    bsblan._temperature._circuit_temp_ranges[1] = {"min": 10.0, "max": 30.0}
+    bsblan._temperature._circuit_temp_initialized.add(1)
 
     # Test with valid value (should not raise exception)
     await bsblan._validate_target_temperature("22.0")
@@ -87,7 +87,7 @@ async def test_validate_target_temperature_high_no_range() -> None:
     async def mock_init_temp_range(circuit: int = 1) -> None:
         pass
 
-    bsblan._initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
+    bsblan._temperature.initialize_temperature_range = mock_init_temp_range  # type: ignore[method-assign]
 
     await bsblan._validate_target_temperature_high("32.0")
 
@@ -98,8 +98,11 @@ async def test_validate_target_temperature_high_invalid_value() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    bsblan._circuit_temp_ranges[1] = {"cooling_min": 18.0, "cooling_max": 26.0}
-    bsblan._circuit_temp_initialized.add(1)
+    bsblan._temperature._circuit_temp_ranges[1] = {
+        "cooling_min": 18.0,
+        "cooling_max": 26.0,
+    }
+    bsblan._temperature._circuit_temp_initialized.add(1)
 
     with pytest.raises(BSBLANInvalidParameterError):
         await bsblan._validate_target_temperature_high("invalid")
@@ -111,8 +114,11 @@ async def test_validate_target_temperature_high_out_of_range() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    bsblan._circuit_temp_ranges[1] = {"cooling_min": 18.0, "cooling_max": 26.0}
-    bsblan._circuit_temp_initialized.add(1)
+    bsblan._temperature._circuit_temp_ranges[1] = {
+        "cooling_min": 18.0,
+        "cooling_max": 26.0,
+    }
+    bsblan._temperature._circuit_temp_initialized.add(1)
 
     with pytest.raises(BSBLANInvalidParameterError):
         await bsblan._validate_target_temperature_high("17.5")
@@ -127,8 +133,11 @@ async def test_validate_target_temperature_high_valid() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    bsblan._circuit_temp_ranges[1] = {"cooling_min": 18.0, "cooling_max": 26.0}
-    bsblan._circuit_temp_initialized.add(1)
+    bsblan._temperature._circuit_temp_ranges[1] = {
+        "cooling_min": 18.0,
+        "cooling_max": 26.0,
+    }
+    bsblan._temperature._circuit_temp_initialized.add(1)
 
     await bsblan._validate_target_temperature_high("21.0")
 
@@ -166,7 +175,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
         await client._initialize_temperature_range()
 
         # min should remain None when neither protective nor pps min is available
-        temp_range = client._circuit_temp_ranges.get(1, {})
+        temp_range = client._temperature._circuit_temp_ranges.get(1, {})
         assert temp_range.get("min") is None
 
 
@@ -202,7 +211,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
         await client._initialize_temperature_range()
 
         # max_temp should remain None
-        temp_range = client._circuit_temp_ranges.get(1, {})
+        temp_range = client._temperature._circuit_temp_ranges.get(1, {})
         assert temp_range.get("max") is None
 
 
@@ -233,6 +242,6 @@ async def test_temperature_range_static_values_error(monkeypatch: Any) -> None:
         await client._initialize_temperature_range()
 
         # Both should remain None
-        temp_range = client._circuit_temp_ranges.get(1, {})
+        temp_range = client._temperature._circuit_temp_ranges.get(1, {})
         assert temp_range.get("min") is None
         assert temp_range.get("max") is None

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -42,8 +42,8 @@ async def mock_bsblan() -> AsyncGenerator[BSBLAN, None]:
         bsblan = BSBLAN(config, session=session)
         bsblan._firmware_version = "1.0.38-20200730234859"
         bsblan._api_version = "v3"
-        bsblan._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
-        bsblan._circuit_temp_initialized.add(1)
+        bsblan._temperature._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
+        bsblan._temperature._circuit_temp_initialized.add(1)
         yield bsblan
 
 


### PR DESCRIPTION
Move per-circuit temperature range cache, the initialized-circuit set, the active temperature unit, and all temperature range/unit/bounds logic out of the BSBLAN god object into a dedicated TemperatureManager collaborator in src/bsblan/_temperature.py.

The manager reads discovered circuits and fetches static values through injected callables, so it holds no back-reference to the facade (matching the SectionValidator/VersionResolver/BSBLANTransport pattern). The facade keeps thin delegations (_should_extract_temperature_unit, _extract_temperature_unit_from_response, _initialize_temperature_range, _validate_target_temperature[_high], get_temperature_unit) so the public API and test seams are unchanged.

Behavior-preserving: no public API changes. Tests reach the moved state via bsblan._temperature.*. 458 passed, 100% coverage.

<details>
<summary>Details</summary>

This pull request refactors the temperature management logic in the BSBLAN client by extracting all temperature-related state and validation into a new `TemperatureManager` class. This change centralizes temperature unit handling, per-circuit temperature range caching, and bounds checking, leading to a cleaner and more maintainable codebase. The BSBLAN client now delegates all temperature-related responsibilities to this new manager.

Key changes by theme:

**Temperature Management Refactoring:**

* Introduced a new `TemperatureManager` class in `src/bsblan/_temperature.py` that encapsulates temperature unit management, per-circuit temperature range caching, and validation logic, including lazy loading of device static values and bounds checks.
* Replaced all direct temperature state and logic in `BSBLAN` with delegation to `TemperatureManager`, removing the previous scattered implementation and fields (`_temperature_unit`, `_circuit_temp_ranges`, `_circuit_temp_initialized`). [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L108-R112) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428R123-R126)

**Codebase Simplification and API Changes:**

* Updated all internal methods in `BSBLAN` that previously handled temperature unit extraction, range initialization, and temperature validation to delegate to the corresponding methods on `TemperatureManager`. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L288-R290) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L338-R334) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L463-L566) [[4]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L584-R455) [[5]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L627-R493) [[6]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1080-L1133) [[7]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1155-L1159)
* Removed redundant temperature validation and range-fetching logic from `BSBLAN`, ensuring all such logic is now centralized in `TemperatureManager`. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L463-L566) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L1080-L1133)

**Tests Update:**

* Updated tests to reference the new location of the temperature unit state within `TemperatureManager`.

</details>