### PR TITLE
Use JSON-API version as sole configuration selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,23 +54,23 @@ authentication setup, see the [Getting Started][docs-getting-started] guide.
 ## Compatibility
 
 The client automatically detects the device's capabilities during
-`initialize()` and selects a matching configuration:
+`initialize()` and selects a matching configuration based on the BSB-LAN
+JSON-API version reported by the `/JV` endpoint:
 
-- **Full support (`v3`)** — modern BSB-LAN firmware (3.x and newer, including
-  4.x and 5.x). All features are available: multiple heating circuits, hot
-  water control, schedules, sensors, and cooling setpoints.
-- **Basic support (`v2`)** — the legacy 2.x firmware branch. A reduced,
-  single-circuit configuration covering essential heating, hot water, and
-  sensor parameters.
+- **Full support (`v3`)** — JSON-API version 2.0 or newer. All features are
+  available: multiple heating circuits, hot water control, schedules, sensors,
+  and cooling setpoints.
+- **Basic support (`v2`)** — JSON-API version 1.x. A reduced, single-circuit
+  configuration covering essential heating, hot water, and sensor parameters.
 
-Detection prefers the documented BSB-LAN JSON-API version reported by the
-`/JV` endpoint, which is independent of the adapter firmware version. When a
-device does not expose `/JV` (very old firmware), the firmware version reported
-by `/JI` is used as a fallback. Firmware older than the 2.x branch is not
-supported.
+The JSON-API version is the documented, firmware-independent compatibility
+signal. The adapter firmware version (from `/JI`) is still retrieved and
+exposed via `device_info`, but it is not used to determine support. A device
+that does not expose `/JV`, or reports a JSON-API version below 1.0, is not
+supported and raises `BSBLANVersionError` during `initialize()`.
 
-> Note: basic 2.x support is best-effort and may not cover every parameter your
-> heating system exposes.
+> Note: basic (JSON-API 1.x) support is best-effort and may not cover every
+> parameter your heating system exposes.
 
 ## Changelog & Releases
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,22 +66,23 @@ asyncio.run(main())
 ## Firmware compatibility
 
 On the first request the client lazily runs `initialize()`, which detects the
-device's capabilities and selects a matching configuration:
+device's capabilities and selects a matching configuration based on the BSB-LAN
+JSON-API version reported by the `/JV` endpoint:
 
-- **Full support (`v3`)** — BSB-LAN firmware 3.x and newer (including 4.x and
-  5.x). All features are available, including multiple heating circuits, hot
-  water control, schedules, sensors, and cooling setpoints.
-- **Basic support (`v2`)** — the legacy 2.x firmware branch. A reduced,
-  single-circuit configuration covering essential heating, hot water, and
-  sensor parameters.
+- **Full support (`v3`)** — JSON-API version 2.0 or newer. All features are
+  available, including multiple heating circuits, hot water control, schedules,
+  sensors, and cooling setpoints.
+- **Basic support (`v2`)** — JSON-API version 1.x. A reduced, single-circuit
+  configuration covering essential heating, hot water, and sensor parameters.
 
-Detection prefers the BSB-LAN JSON-API version reported by the `/JV` endpoint,
-which is independent of the adapter firmware version. When a device does not
-expose `/JV` (very old firmware), the firmware version from `/JI` is used as a
-fallback. Firmware older than the 2.x branch raises `BSBLANVersionError`.
+The JSON-API version is the documented, firmware-independent compatibility
+signal. The adapter firmware version (from `/JI`) is still retrieved and exposed
+via `device_info`, but it is not used to determine support. A device that does
+not expose `/JV`, or reports a JSON-API version below 1.0, raises
+`BSBLANVersionError`.
 
-Basic 2.x support is best-effort and may not cover every parameter your heating
-system exposes.
+Basic (JSON-API 1.x) support is best-effort and may not cover every parameter
+your heating system exposes.
 
 ## Temperature bounds
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) d
 - Control thermostat settings and hot water parameters
 - Detect optional cooling setpoints for heat/cool range controls
 - Fully typed with PEP 561 support
-- API v3 parameter support, plus basic support for the legacy 2.x firmware
+- API v3 parameter support, plus basic support for JSON-API 1.x devices
 - Automatic version detection via the BSB-LAN JSON-API (`/JV`)
 - Lazy loading with per-section validation
 

--- a/src/bsblan/_version.py
+++ b/src/bsblan/_version.py
@@ -1,10 +1,10 @@
 """API version resolution for the BSBLAN client.
 
-Owns the policy that maps a device's reported version signals to a supported
-API configuration version. The BSB-LAN JSON-API version (from ``/JV``) is the
-documented, firmware-independent compatibility signal and is preferred when
-available; the adapter firmware version (from ``/JI``) is used as a fallback
-for very old firmware that does not expose ``/JV``.
+Owns the policy that maps a device's reported BSB-LAN JSON-API version (from
+``/JV``) to a supported API configuration version. The JSON-API version is the
+documented, firmware-independent compatibility signal and is the sole input for
+selecting the configuration. The adapter firmware version (from ``/JI``) is
+retrieved for informational purposes only and is not checked here.
 """
 
 from __future__ import annotations
@@ -14,14 +14,12 @@ from packaging.version import InvalidVersion
 
 from .constants import (
     BASIC_API_VERSION,
-    MIN_SUPPORTED_FIRMWARE,
     MIN_SUPPORTED_JSON_API,
     SUPPORTED_API_VERSION,
-    V3_FIRMWARE_MINIMUM,
     V3_JSON_API_MINIMUM,
     ErrorMsg,
 )
-from .exceptions import BSBLANError, BSBLANVersionError
+from .exceptions import BSBLANVersionError
 
 
 def _map_reported_version(reported: str, *, minimum: str, v3_minimum: str) -> str:
@@ -55,72 +53,53 @@ def _map_reported_version(reported: str, *, minimum: str, v3_minimum: str) -> st
 
 
 class VersionResolver:
-    """Resolve the API configuration version from reported device versions.
+    """Resolve the API configuration version from the JSON-API version.
 
-    The resolver is configured with the version floors and ``v3`` thresholds
-    for both the JSON-API and firmware signals. Defaults use the library's
-    named constants; custom thresholds can be supplied for testing.
+    The resolver is configured with the JSON-API version floor and the ``v3``
+    threshold. Defaults use the library's named constants; custom thresholds
+    can be supplied for testing.
     """
 
     def __init__(
         self,
         *,
-        firmware_minimum: str = MIN_SUPPORTED_FIRMWARE,
-        firmware_v3_minimum: str = V3_FIRMWARE_MINIMUM,
         json_api_minimum: str = MIN_SUPPORTED_JSON_API,
         json_api_v3_minimum: str = V3_JSON_API_MINIMUM,
     ) -> None:
         """Initialize the resolver with version policy thresholds.
 
         Args:
-            firmware_minimum: Lowest supported adapter firmware version.
-            firmware_v3_minimum: Firmware version at/above which "v3" is used.
             json_api_minimum: Lowest supported JSON-API version.
             json_api_v3_minimum: JSON-API version at/above which "v3" is used.
 
         """
-        self._firmware_minimum = firmware_minimum
-        self._firmware_v3_minimum = firmware_v3_minimum
         self._json_api_minimum = json_api_minimum
         self._json_api_v3_minimum = json_api_v3_minimum
 
-    def resolve_config_version(
-        self,
-        *,
-        json_api_version: str | None,
-        firmware_version: str | None,
-    ) -> str:
-        """Resolve the API config version from the available version signals.
+    def resolve_config_version(self, *, json_api_version: str | None) -> str:
+        """Resolve the API config version from the JSON-API version.
 
-        The JSON-API version is preferred when present; otherwise the firmware
-        version is used as a fallback.
+        The BSB-LAN JSON-API version reported by ``/JV`` is the sole signal for
+        selecting the configuration. The adapter firmware version is not
+        considered.
 
         Args:
             json_api_version: The JSON-API version reported by ``/JV``, or None.
-            firmware_version: The adapter firmware version from ``/JI``, or None.
 
         Returns:
             ``"v2"`` for the basic single-circuit config or ``"v3"`` for the
             full config.
 
         Raises:
-            BSBLANError: If neither the JSON-API version nor the firmware
-                version is available.
-            BSBLANVersionError: If the reported version is not supported.
+            BSBLANVersionError: If the JSON-API version is unavailable or the
+                reported version is not supported.
 
         """
-        if json_api_version is not None:
-            return _map_reported_version(
-                json_api_version,
-                minimum=self._json_api_minimum,
-                v3_minimum=self._json_api_v3_minimum,
-            )
-
-        if not firmware_version:
-            raise BSBLANError(ErrorMsg.FIRMWARE_VERSION)
+        if json_api_version is None:
+            raise BSBLANVersionError(ErrorMsg.VERSION)
 
         return _map_reported_version(
-            firmware_version,
-            minimum=self._firmware_minimum,
-            v3_minimum=self._firmware_v3_minimum,
+            json_api_version,
+            minimum=self._json_api_minimum,
+            v3_minimum=self._json_api_v3_minimum,
         )

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -420,19 +420,17 @@ class BSBLAN:
         """Set the API version used to select the configuration.
 
         The BSB-LAN JSON-API version (from /JV) is the documented,
-        firmware-independent compatibility signal and is preferred when
-        available. When the device does not expose /JV (very old firmware), the
-        adapter firmware version (from /JI) is used as a fallback.
+        firmware-independent compatibility signal and is the sole input for
+        selecting the API configuration. The adapter firmware version (from
+        /JI) is retrieved for informational purposes only and is not checked.
 
         Raises:
-            BSBLANError: If neither the JSON-API version nor the firmware
-                version is available.
-            BSBLANVersionError: If the reported version is not supported.
+            BSBLANVersionError: If the JSON-API version is unavailable or the
+                reported version is not supported.
 
         """
         self._api_version = self._version_resolver.resolve_config_version(
             json_api_version=self._json_api_version,
-            firmware_version=self._firmware_version,
         )
 
     async def _initialize_temperature_range(

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -21,22 +21,14 @@ SUPPORTED_API_VERSIONS: Final[tuple[str, ...]] = (
     SUPPORTED_API_VERSION,
 )
 
-# Firmware version thresholds (BSB-LAN adapter firmware, from /JI).
-# Firmware below MIN_SUPPORTED_FIRMWARE is rejected outright. Firmware in the
-# [MIN_SUPPORTED_FIRMWARE, V3_FIRMWARE_MINIMUM) range maps to the basic "v2"
-# config, and firmware >= V3_FIRMWARE_MINIMUM maps to the full "v3" config.
-# The firmware version is only used as a fallback when the JSON-API version
-# (from /JV) is not available (very old firmware that predates that endpoint).
-MIN_SUPPORTED_FIRMWARE: Final[str] = "2.0.0"
-V3_FIRMWARE_MINIMUM: Final[str] = "3.0.0"
-
-# JSON-API version thresholds (from /JV, distinct from adapter firmware).
+# JSON-API version thresholds (from /JV).
 # The /JV endpoint reports the BSB-LAN JSON-API version (e.g. "2.0"), which is
-# the documented, firmware-independent compatibility signal. When available it
-# is the primary signal for selecting the API config: a JSON-API version below
-# MIN_SUPPORTED_JSON_API is rejected, the [MIN_SUPPORTED_JSON_API,
-# V3_JSON_API_MINIMUM) range maps to the basic "v2" config, and a version
-# >= V3_JSON_API_MINIMUM maps to the full "v3" config.
+# the documented, firmware-independent compatibility signal and the sole input
+# for selecting the API config: a JSON-API version below MIN_SUPPORTED_JSON_API
+# is rejected, the [MIN_SUPPORTED_JSON_API, V3_JSON_API_MINIMUM) range maps to
+# the basic "v2" config, and a version >= V3_JSON_API_MINIMUM maps to the full
+# "v3" config. The adapter firmware version (from /JI) is retrieved for
+# informational purposes only and is not used to select the config.
 MIN_SUPPORTED_JSON_API: Final[str] = "1.0"
 V3_JSON_API_MINIMUM: Final[str] = "2.0"
 
@@ -539,7 +531,6 @@ class ErrorMsg:
     NO_STATE = "No state provided."
     NO_SCHEDULE = "No schedule provided."
     VERSION = "Version not supported"
-    FIRMWARE_VERSION = "Firmware version not available"
     TEMPERATURE_RANGE = "Temperature range not initialized"
     API_VERSION = "API version not set"
     MULTI_PARAMETER = "Only one parameter can be set at a time"

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -13,78 +13,31 @@ from bsblan.models import Device
 
 
 @pytest.mark.asyncio
-async def test_set_api_version_without_firmware() -> None:
-    """Test setting API version with firmware version not set."""
+async def test_set_api_version_without_json_api() -> None:
+    """Test that a missing JSON-API version raises BSBLANVersionError."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Firmware version is None by default
-    with pytest.raises(BSBLANError, match=ErrorMsg.FIRMWARE_VERSION):
-        bsblan._set_api_version()
-
-
-@pytest.mark.asyncio
-async def test_set_api_version_unsupported() -> None:
-    """Test setting API version with unsupported firmware version."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Set firmware version below the supported floor (< 2.0.0)
-    bsblan._firmware_version = "1.9.0"
-
+    # No JSON-API version available (device did not expose /JV).
     with pytest.raises(BSBLANVersionError):
         bsblan._set_api_version()
 
 
 @pytest.mark.asyncio
-async def test_set_api_version_v2_basic() -> None:
-    """Test legacy 2.x firmware maps to the basic v2 config."""
+async def test_set_api_version_ignores_firmware() -> None:
+    """Test the firmware version is not used to select the configuration.
+
+    Even a modern firmware version cannot stand in for a missing JSON-API
+    version: without /JV the device capabilities cannot be confirmed.
+    """
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    bsblan._firmware_version = "2.2.3"
-    bsblan._set_api_version()
-
-    assert bsblan._api_version == "v2"
-
-
-@pytest.mark.asyncio
-async def test_set_api_version_rejects_legacy_firmware() -> None:
-    """Test legacy firmware that previously mapped to v1 is unsupported."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Set firmware version to legacy v1-compatible firmware
-    bsblan._firmware_version = "1.0.0"
+    # Firmware is retrieved for information only; it must not gate support.
+    bsblan._firmware_version = "5.0.16"
 
     with pytest.raises(BSBLANVersionError):
         bsblan._set_api_version()
-
-
-@pytest.mark.asyncio
-async def test_set_api_version_invalid_firmware_string() -> None:
-    """Test non-PEP440 firmware strings raise BSBLANVersionError."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Firmware strings with build metadata are not PEP 440 compliant
-    bsblan._firmware_version = "1.0.38-not-a-version"
-
-    with pytest.raises(BSBLANVersionError):
-        bsblan._set_api_version()
-
-
-@pytest.mark.asyncio
-async def test_set_api_version_v3() -> None:
-    """Test setting API version with v3 compatible firmware."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Set firmware version to v3 compatible
-    bsblan._firmware_version = "3.0.0"
-    bsblan._set_api_version()
-
-    assert bsblan._api_version == "v3"
 
 
 @pytest.mark.asyncio
@@ -121,32 +74,6 @@ async def test_setup_api_validator_no_api_version() -> None:
 
     with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
         await bsblan._setup_api_validator()
-
-
-@pytest.mark.asyncio
-async def test_set_api_version_v5() -> None:
-    """Test setting API version with v5 compatible firmware (BSB-LAN 5.x)."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Set firmware version to 5.0.16 (current BSB-LAN version)
-    bsblan._firmware_version = "5.0.16"
-    bsblan._set_api_version()
-
-    assert bsblan._api_version == "v3"
-
-
-@pytest.mark.asyncio
-async def test_set_api_version_v5_early() -> None:
-    """Test setting API version with early v5 compatible firmware."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Set firmware version to 5.0.0 (first 5.x version)
-    bsblan._firmware_version = "5.0.0"
-    bsblan._set_api_version()
-
-    assert bsblan._api_version == "v3"
 
 
 @pytest.mark.asyncio
@@ -203,53 +130,6 @@ async def test_process_response_non_jq_endpoint() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_api_version_v5_edge_cases() -> None:
-    """Test edge cases for BSB-LAN 5.x version detection."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Test version 4.9.9 (should still be v3, not v5)
-    bsblan._firmware_version = "4.9.9"
-    bsblan._set_api_version()
-    assert bsblan._api_version == "v3"
-
-    # Test version 5.0.0-beta (should be v3)
-    bsblan._firmware_version = "5.0.0"
-    bsblan._set_api_version()
-    assert bsblan._api_version == "v3"
-
-
-@pytest.mark.asyncio
-async def test_unsupported_version_still_fails() -> None:
-    """Test that firmware below the supported floor (< 2.0.0) still fails."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # Test that version 1.9.9 still fails
-    bsblan._firmware_version = "1.9.9"
-
-    with pytest.raises(BSBLANVersionError):
-        bsblan._set_api_version()
-
-
-@pytest.mark.asyncio
-async def test_legacy_2x_maps_to_basic_v2() -> None:
-    """Test that legacy 2.x firmware maps to the basic v2 config."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    # 2.0.0 is the lower bound of basic support
-    bsblan._firmware_version = "2.0.0"
-    bsblan._set_api_version()
-    assert bsblan._api_version == "v2"
-
-    # 2.9.9 still maps to basic v2 (below the 3.0.0 v3 threshold)
-    bsblan._firmware_version = "2.9.9"
-    bsblan._set_api_version()
-    assert bsblan._api_version == "v2"
-
-
-@pytest.mark.asyncio
 async def test_json_api_version_v3() -> None:
     """Test JSON-API version >= 2.0 maps to the full v3 config."""
     config = BSBLANConfig(host="example.com")
@@ -298,13 +178,13 @@ async def test_json_api_version_invalid_string() -> None:
 
 
 @pytest.mark.asyncio
-async def test_json_api_version_takes_precedence_over_firmware() -> None:
-    """Test the JSON-API version is preferred over the firmware version."""
+async def test_json_api_version_used_regardless_of_firmware() -> None:
+    """Test the JSON-API version alone selects the config, ignoring firmware."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Firmware would map to v2, but a modern JSON-API version wins.
-    bsblan._firmware_version = "2.2.3"
+    # Firmware is informational only; the JSON-API version drives the result.
+    bsblan._firmware_version = "1.0.0"
     bsblan._json_api_version = "2.0"
     bsblan._set_api_version()
 
@@ -342,12 +222,12 @@ async def test_version_error_exposes_version() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    bsblan._firmware_version = "1.9.0"
+    bsblan._json_api_version = "0.9"
 
     with pytest.raises(BSBLANVersionError) as exc_info:
         bsblan._set_api_version()
 
-    assert exc_info.value.version == "1.9.0"
+    assert exc_info.value.version == "0.9"
 
 
 @pytest.mark.asyncio
@@ -425,5 +305,5 @@ async def test_fetch_firmware_version_queries_json_api() -> None:
 
     assert bsblan._firmware_version == "2.2.3"
     assert bsblan._json_api_version == "2.0"
-    # JSON-API version wins over the legacy firmware mapping.
+    # The JSON-API version drives the result; firmware is informational only.
     assert bsblan._api_version == "v3"


### PR DESCRIPTION
This pull request updates the BSBLAN client and documentation to simplify and clarify version compatibility handling. The client now uses only the BSB-LAN JSON-API version (`/JV` endpoint) to determine supported features and configuration, removing all fallback logic and support based on adapter firmware version (`/JI`). Firmware version is still retrieved for informational purposes but no longer affects compatibility or feature selection. The documentation and tests have been updated to reflect this streamlined policy.

The most important changes are:

**Core compatibility logic:**

* The client now uses only the JSON-API version reported by `/JV` to select the configuration (either full `v3` support for JSON-API >= 2.0, or basic `v2` support for JSON-API 1.x). Devices without `/JV`, or with JSON-API < 1.0, are not supported. Firmware version is never used to determine compatibility. (`src/bsblan/_version.py`, `src/bsblan/bsblan.py`, `src/bsblan/constants.py`) [[1]](diffhunk://#diff-aa0d41eaa22404d2057bc28326749b64496bc530b696c343a984862468a9fc23L3-R7) [[2]](diffhunk://#diff-aa0d41eaa22404d2057bc28326749b64496bc530b696c343a984862468a9fc23L58-L126) [[3]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L423-L435) [[4]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL24-R31) [[5]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL542)

**Documentation updates:**

* All user-facing documentation (README, getting started, index) has been rewritten to clarify that only the JSON-API version is used for compatibility, and to remove references to firmware-based detection or support. (`README.md`, `docs/getting-started.md`, `docs/index.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R73) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L69-R85) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L12-R12)

**Test suite updates:**

* The test suite has been refactored to remove all tests related to firmware-based compatibility, and to add/adjust tests to confirm that only the JSON-API version determines support. Tests now ensure that the firmware version is ignored for compatibility, and that missing or unsupported JSON-API versions raise the correct errors. (`tests/test_version_errors.py`) [[1]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL16-L89) [[2]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL126-L151) [[3]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL205-L251) [[4]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL301-R187) [[5]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL345-R230) [[6]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL428-R308)