### PR TITLE
Remove public api_version property and describe config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ The client automatically detects the device's capabilities during
 `initialize()` and selects a matching configuration based on the BSB-LAN
 JSON-API version reported by the `/JV` endpoint:
 
-- **Full support (`v3`)** — JSON-API version 2.0 or newer. All features are
+- **Full configuration** — JSON-API version 2.0 or newer. All features are
   available: multiple heating circuits, hot water control, schedules, sensors,
   and cooling setpoints.
-- **Basic support (`v2`)** — JSON-API version 1.x. A reduced, single-circuit
+- **Basic configuration** — JSON-API version 1.x. A reduced, single-circuit
   configuration covering essential heating, hot water, and sensor parameters.
 
 The JSON-API version is the documented, firmware-independent compatibility

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,10 +69,10 @@ On the first request the client lazily runs `initialize()`, which detects the
 device's capabilities and selects a matching configuration based on the BSB-LAN
 JSON-API version reported by the `/JV` endpoint:
 
-- **Full support (`v3`)** — JSON-API version 2.0 or newer. All features are
+- **Full configuration** — JSON-API version 2.0 or newer. All features are
   available, including multiple heating circuits, hot water control, schedules,
   sensors, and cooling setpoints.
-- **Basic support (`v2`)** — JSON-API version 1.x. A reduced, single-circuit
+- **Basic configuration** — JSON-API version 1.x. A reduced, single-circuit
   configuration covering essential heating, hot water, and sensor parameters.
 
 The JSON-API version is the documented, firmware-independent compatibility

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) d
 - Control thermostat settings and hot water parameters
 - Detect optional cooling setpoints for heat/cool range controls
 - Fully typed with PEP 561 support
-- API v3 parameter support, plus basic support for JSON-API 1.x devices
-- Automatic version detection via the BSB-LAN JSON-API (`/JV`)
+- Full parameter support, plus basic support for JSON-API 1.x devices
+- Automatic capability detection via the BSB-LAN JSON-API (`/JV`)
 - Lazy loading with per-section validation
 
 ## Quick example

--- a/examples/control.py
+++ b/examples/control.py
@@ -174,7 +174,6 @@ def print_device_time(device_time: DeviceTime) -> None:
 def print_device_info(
     device: Device,
     info: Info,
-    api_version: str | None = None,
     json_api_version: str | None = None,
 ) -> None:
     """Print device and general information.
@@ -182,8 +181,6 @@ def print_device_info(
     Args:
         device (Device): The device information from the BSBLan device.
         info (Info): The general information from the BSBLan device.
-        api_version (str | None): The resolved API configuration version
-            (``"v2"`` or ``"v3"``).
         json_api_version (str | None): The BSB-LAN JSON-API version reported by
             the ``/JV`` endpoint, if available.
 
@@ -191,7 +188,6 @@ def print_device_info(
     attributes = {
         "Device Name": device.name or "N/A",
         "Version": device.version or "N/A",
-        "API Version (config)": format_optional(api_version),
         "JSON-API Version (/JV)": format_optional(json_api_version),
         "Device Identification": get_attribute(info.device_identification),
         "Bus Type": format_optional(device.bus),
@@ -353,7 +349,6 @@ async def main() -> None:
         print_device_info(
             device,
             info,
-            api_version=bsblan.api_version,
             json_api_version=bsblan.json_api_version,
         )
 

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -378,21 +378,12 @@ class BSBLAN:
         return self._device
 
     @property
-    def api_version(self) -> str | None:
-        """Return the resolved API configuration version (``"v2"`` or ``"v3"``).
-
-        The value is populated during initialization. ``"v3"`` indicates full
-        support and ``"v2"`` the basic single-circuit configuration.
-        """
-        return self._api_version
-
-    @property
     def json_api_version(self) -> str | None:
         """Return the BSB-LAN JSON-API version reported by ``/JV``.
 
-        This is the firmware-independent JSON-API version (e.g. ``"2.0"``).
-        Returns ``None`` when the device does not expose the ``/JV`` endpoint,
-        in which case the firmware version is used to resolve ``api_version``.
+        This is the firmware-independent JSON-API version (e.g. ``"2.0"``) and
+        the signal used to select the device configuration. Returns ``None``
+        until ``/JV`` has been queried during initialization.
         """
         return self._json_api_version
 

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -192,18 +192,6 @@ async def test_json_api_version_used_regardless_of_firmware() -> None:
 
 
 @pytest.mark.asyncio
-async def test_api_version_property() -> None:
-    """Test the public api_version property reflects the resolved version."""
-    config = BSBLANConfig(host="example.com")
-    bsblan = BSBLAN(config)
-
-    bsblan._json_api_version = "2.0"
-    bsblan._set_api_version()
-
-    assert bsblan.api_version == "v3"
-
-
-@pytest.mark.asyncio
 async def test_json_api_version_property() -> None:
     """Test the public json_api_version property exposes the /JV version."""
     config = BSBLANConfig(host="example.com")


### PR DESCRIPTION
This pull request focuses on clarifying terminology and simplifying the public API related to device capability detection and version reporting. It removes the `api_version` property and references, consolidating on the use of `json_api_version` for configuration selection and documentation. Documentation and example code are updated to reflect these changes.

**Public API simplification:**
- Removed the `api_version` property from the `BSBLAN` class and all related references, consolidating version reporting to use only `json_api_version` for clarity and to prevent confusion. [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L380-R386) [[2]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L177-L194) [[3]](diffhunk://#diff-826d5ef95cfd018524ef5ed9de4efb25bb5ac74495079a16cbec64c4eeb05692L356) [[4]](diffhunk://#diff-5bd376f280ebbf9b96257d6900d735e0034846636f74f232ec16ea94489dfb3eL194-L205)

**Documentation and terminology updates:**
- Updated documentation and user-facing descriptions to clarify that configuration selection is based on device "capabilities" and "configuration" rather than "support" or "API version," improving accuracy and user understanding. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L12-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R63) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L72-R75)
- Adjusted comments and docstrings to reflect the new terminology and configuration selection logic, ensuring consistency throughout the codebase.