### PR TITLE
Replace internal v2/v3 selector with supports_full_config flag

### DIFF
--- a/src/bsblan/_version.py
+++ b/src/bsblan/_version.py
@@ -1,7 +1,7 @@
-"""API version resolution for the BSBLAN client.
+"""API capability resolution for the BSBLAN client.
 
 Owns the policy that maps a device's reported BSB-LAN JSON-API version (from
-``/JV``) to a supported API configuration version. The JSON-API version is the
+``/JV``) to a supported API configuration. The JSON-API version is the
 documented, firmware-independent compatibility signal and is the sole input for
 selecting the configuration. The adapter firmware version (from ``/JI``) is
 retrieved for informational purposes only and is not checked here.
@@ -13,51 +13,19 @@ from packaging import version as pkg_version
 from packaging.version import InvalidVersion
 
 from .constants import (
-    BASIC_API_VERSION,
     MIN_SUPPORTED_JSON_API,
-    SUPPORTED_API_VERSION,
     V3_JSON_API_MINIMUM,
     ErrorMsg,
 )
 from .exceptions import BSBLANVersionError
 
 
-def _map_reported_version(reported: str, *, minimum: str, v3_minimum: str) -> str:
-    """Map a reported version string to a supported API config version.
-
-    Args:
-        reported: The version string reported by the device.
-        minimum: The lowest supported version; anything below is rejected.
-        v3_minimum: The threshold at or above which the full "v3" config is
-            used; below it the basic "v2" config is used.
-
-    Returns:
-        ``"v2"`` for the basic single-circuit config or ``"v3"`` for the full
-        config.
-
-    Raises:
-        BSBLANVersionError: If the reported version cannot be parsed or is
-            below ``minimum``.
-
-    """
-    try:
-        parsed = pkg_version.parse(reported)
-    except InvalidVersion as exc:
-        raise BSBLANVersionError(ErrorMsg.VERSION, version=reported) from exc
-    if parsed < pkg_version.parse(minimum):
-        raise BSBLANVersionError(ErrorMsg.VERSION, version=reported)
-    if parsed < pkg_version.parse(v3_minimum):
-        # Legacy / basic capability: single-circuit support only.
-        return BASIC_API_VERSION
-    return SUPPORTED_API_VERSION
-
-
 class VersionResolver:
-    """Resolve the API configuration version from the JSON-API version.
+    """Resolve the API capability from the JSON-API version.
 
-    The resolver is configured with the JSON-API version floor and the ``v3``
-    threshold. Defaults use the library's named constants; custom thresholds
-    can be supplied for testing.
+    The resolver is configured with the JSON-API version floor and the full
+    configuration threshold. Defaults use the library's named constants;
+    custom thresholds can be supplied for testing.
     """
 
     def __init__(
@@ -70,14 +38,15 @@ class VersionResolver:
 
         Args:
             json_api_minimum: Lowest supported JSON-API version.
-            json_api_v3_minimum: JSON-API version at/above which "v3" is used.
+            json_api_v3_minimum: JSON-API version at/above which the full
+                configuration is used.
 
         """
         self._json_api_minimum = json_api_minimum
         self._json_api_v3_minimum = json_api_v3_minimum
 
-    def resolve_config_version(self, *, json_api_version: str | None) -> str:
-        """Resolve the API config version from the JSON-API version.
+    def supports_full_config(self, *, json_api_version: str | None) -> bool:
+        """Determine whether the device supports the full configuration.
 
         The BSB-LAN JSON-API version reported by ``/JV`` is the sole signal for
         selecting the configuration. The adapter firmware version is not
@@ -87,8 +56,8 @@ class VersionResolver:
             json_api_version: The JSON-API version reported by ``/JV``, or None.
 
         Returns:
-            ``"v2"`` for the basic single-circuit config or ``"v3"`` for the
-            full config.
+            ``True`` when the full configuration is supported, ``False`` for the
+            basic single-circuit configuration.
 
         Raises:
             BSBLANVersionError: If the JSON-API version is unavailable or the
@@ -97,9 +66,12 @@ class VersionResolver:
         """
         if json_api_version is None:
             raise BSBLANVersionError(ErrorMsg.VERSION)
-
-        return _map_reported_version(
-            json_api_version,
-            minimum=self._json_api_minimum,
-            v3_minimum=self._json_api_v3_minimum,
-        )
+        try:
+            parsed = pkg_version.parse(json_api_version)
+        except InvalidVersion as exc:
+            raise BSBLANVersionError(
+                ErrorMsg.VERSION, version=json_api_version
+            ) from exc
+        if parsed < pkg_version.parse(self._json_api_minimum):
+            raise BSBLANVersionError(ErrorMsg.VERSION, version=json_api_version)
+        return parsed >= pkg_version.parse(self._json_api_v3_minimum)

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -19,9 +19,6 @@ from ._version import VersionResolver
 from .constants import (
     API_V2,
     API_V3,
-    BASIC_API_VERSION,
-    SUPPORTED_API_VERSION,
-    SUPPORTED_API_VERSIONS,
     APIConfig,
     CircuitConfig,
     ErrorMsg,
@@ -33,7 +30,6 @@ from .exceptions import (
     BSBLANConnectionError,
     BSBLANError,
     BSBLANInvalidParameterError,
-    BSBLANVersionError,
 )
 from .models import (
     ApiVersion,
@@ -102,7 +98,7 @@ class BSBLAN:
     _close_session: bool = False
     _firmware_version: str | None = None
     _json_api_version: str | None = None
-    _api_version: str | None = SUPPORTED_API_VERSION
+    _supports_full_config: bool | None = None
     _api_data: APIConfig | None = None
     _device: Device | None = None
     _initialized: bool = False
@@ -243,7 +239,7 @@ class BSBLAN:
         This creates the validator infrastructure but defers actual
         section validation until the data is needed (lazy loading).
         """
-        if self._api_version is None:
+        if self._supports_full_config is None:
             raise BSBLANError(ErrorMsg.API_VERSION)
 
         # Initialize API data if not already done
@@ -349,15 +345,16 @@ class BSBLAN:
             self._firmware_version = device.version
             logger.debug("BSBLAN version: %s", self._firmware_version)
             await self._fetch_json_api_version()
-            self._set_api_version()
+            self._resolve_api_capabilities()
 
     async def _fetch_json_api_version(self) -> None:
         """Fetch the BSB-LAN JSON-API version from the /JV endpoint.
 
         The JSON-API version (e.g. ``"2.0"``) is the documented,
-        firmware-independent compatibility signal. Older firmware may not
-        expose the /JV endpoint; in that case the value is left as ``None`` and
-        the firmware version is used as a fallback for selecting the API config.
+        firmware-independent compatibility signal and the sole input for
+        selecting the configuration. Older firmware may not expose the /JV
+        endpoint; in that case the value is left as ``None`` and
+        :meth:`_resolve_api_capabilities` raises ``BSBLANVersionError``.
         """
         if self._json_api_version is not None:
             return
@@ -365,8 +362,8 @@ class BSBLAN:
             response = await self._request(base_path="/JV")
             api_version = ApiVersion.model_validate(response)
         except (BSBLANError, ValueError, KeyError) as exc:
-            # /JV is unavailable or returned an unexpected payload; fall back to
-            # firmware-version based detection.
+            # /JV is unavailable or returned an unexpected payload; leave the
+            # JSON-API version unset so capability resolution can reject it.
             logger.debug("JSON-API version unavailable from /JV: %s", exc)
             return
         self._json_api_version = api_version.api_version
@@ -407,8 +404,8 @@ class BSBLAN:
         if self._device is None:
             await self.device()
 
-    def _set_api_version(self) -> None:
-        """Set the API version used to select the configuration.
+    def _resolve_api_capabilities(self) -> None:
+        """Resolve the API capabilities used to select the configuration.
 
         The BSB-LAN JSON-API version (from /JV) is the documented,
         firmware-independent compatibility signal and is the sole input for
@@ -420,7 +417,7 @@ class BSBLAN:
                 reported version is not supported.
 
         """
-        self._api_version = self._version_resolver.resolve_config_version(
+        self._supports_full_config = self._version_resolver.supports_full_config(
             json_api_version=self._json_api_version,
         )
 
@@ -482,22 +479,18 @@ class BSBLAN:
         return self._temperature.unit
 
     def _copy_api_config(self) -> APIConfig:
-        """Create a copy of the API configuration for the current version.
+        """Create a copy of the API configuration for the current capability.
 
         Returns:
             APIConfig: A deep copy of the API configuration.
 
         Raises:
-            BSBLANError: If the API version is not set.
+            BSBLANError: If the API capability has not been resolved.
 
         """
-        if self._api_version is None:
+        if self._supports_full_config is None:
             raise BSBLANError(ErrorMsg.API_VERSION)
-        if self._api_version not in SUPPORTED_API_VERSIONS:
-            raise BSBLANVersionError(ErrorMsg.VERSION, version=self._api_version)
-        source_config: APIConfig = (
-            API_V2 if self._api_version == BASIC_API_VERSION else API_V3
-        )
+        source_config: APIConfig = API_V3 if self._supports_full_config else API_V2
         return cast(
             "APIConfig",
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ async def mock_bsblan(
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
         request_mock: AsyncMock = AsyncMock(return_value={"status": "ok"})
         monkeypatch.setattr(bsblan, "_request", request_mock)

--- a/tests/test_api_initialization.py
+++ b/tests/test_api_initialization.py
@@ -31,7 +31,7 @@ async def test_api_data_initialized_from_default_config() -> None:
         client = BSBLAN(config, session=session)
 
         # Set up client with minimal state
-        client._api_version = "v3"
+        client._supports_full_config = True
         client._api_data = None  # This should be initialized
 
         # Call _setup_api_validator which should initialize _api_data
@@ -51,7 +51,7 @@ async def test_copy_api_config_raises_without_version() -> None:
         client = BSBLAN(config, session=session)
 
         # Set both to None
-        client._api_version = None
+        client._supports_full_config = None
         client._api_data = None
 
         # This should raise BSBLANError

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -57,7 +57,7 @@ async def test_validate_api_section_success(aresponses: ResponsesMockServer) -> 
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
 
         # Initialize API validator and data
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         api_data_device_section = {
             "5870": {
                 "name": "Device Parameter",
@@ -146,7 +146,7 @@ async def test_validate_api_section_validation_error(
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
 
         # Set up for test
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         api_data_device_section_error = {
             "5870": {
                 "name": "Device Parameter",
@@ -195,7 +195,7 @@ async def test_validate_section_already_validated(monkeypatch: Any) -> None:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v3"
+        client._supports_full_config = True
         # Deep copy to avoid modifying the shared constant
         source_config = API_V3
         client._api_data = cast(
@@ -229,7 +229,7 @@ async def test_validation_error_resets_section(monkeypatch: Any) -> None:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v3"
+        client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
         source_config = API_V3
         client._api_data = cast(
@@ -255,7 +255,7 @@ async def test_setup_api_validator_api_data_already_exists() -> None:
     """Test _setup_api_validator when _api_data already exists."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
 
         # Pre-set api_data
         existing_data = {"heating": {"700": "operating_mode"}}
@@ -273,7 +273,7 @@ async def test_setup_api_validator_initializes_api_data() -> None:
     """Test _setup_api_validator initializes _api_data when None."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
 
         # Ensure _api_data is None
         bsblan._api_data = None
@@ -291,7 +291,7 @@ async def test_ensure_section_validated_double_check_after_lock() -> None:
     """Test double-check locking in _ensure_section_validated."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {"heating": {"700": "operating_mode"}}  # type: ignore[assignment]
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
@@ -326,7 +326,7 @@ async def test_ensure_section_validated_concurrent_double_check() -> None:
     """Test that concurrent calls don't duplicate validation."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {"heating": {"700": "operating_mode"}}  # type: ignore[assignment]
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
@@ -363,7 +363,7 @@ async def test_validate_api_section_hot_water_cache() -> None:
     """Test that hot_water section validation populates the cache."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {
             "heating": {},
             "sensor": {},
@@ -395,7 +395,7 @@ async def test_ensure_section_validated_heating_extracts_temp_unit() -> None:
     """Test that heating section validation extracts temperature unit."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {"heating": {"710": "target_temperature"}}  # type: ignore[assignment]
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
@@ -421,7 +421,7 @@ async def test_setup_api_validator_skips_api_data_init_when_exists() -> None:
     """Test that _setup_api_validator doesn't override existing _api_data."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
 
         # Pre-set custom api_data
         custom_data: dict[str, Any] = {"heating": {"custom": "value"}}

--- a/tests/test_bsblan_edge_cases.py
+++ b/tests/test_bsblan_edge_cases.py
@@ -21,7 +21,7 @@ async def test_validate_api_section_key_error(monkeypatch: Any) -> None:
 
         # Set up basic initialization
         bsblan._firmware_version = "1.0.38-20200730234859"
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {"other_section": {}}  # type: ignore[assignment]
 
         # Mock API validator

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -34,7 +34,7 @@ async def mock_bsblan_circuit() -> AsyncGenerator[BSBLAN, None]:
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(config, session=session)
         bsblan._firmware_version = "1.0.38-20200730234859"
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = build_api_config("v3")
         bsblan._temperature._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
         bsblan._temperature._circuit_temp_initialized.add(1)
@@ -85,7 +85,7 @@ async def test_state_circuit1_default(monkeypatch: Any) -> None:
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         api_data = build_api_config("v3")
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
@@ -118,7 +118,7 @@ async def test_state_circuit2(monkeypatch: Any) -> None:
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(
             bsblan,
             "_api_data",
@@ -159,7 +159,7 @@ async def test_state_circuit2_with_include(monkeypatch: Any) -> None:
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(
             bsblan,
             "_api_data",
@@ -204,7 +204,7 @@ async def test_static_values_circuit2(monkeypatch: Any) -> None:
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(
             bsblan,
             "_api_data",
@@ -470,7 +470,7 @@ async def test_circuit2_temp_range_initialization(
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(
             bsblan,
             "_api_data",
@@ -509,7 +509,7 @@ async def test_circuit1_temp_range_uses_protective_lower_bound(
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         api_data = build_api_config("v3")
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
@@ -548,7 +548,7 @@ async def test_thermostat_circuit2_lazy_temp_init(
             "_firmware_version",
             "1.0.38-20200730234859",
         )
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(
             bsblan,
             "_api_data",

--- a/tests/test_hot_water_additional.py
+++ b/tests/test_hot_water_additional.py
@@ -28,7 +28,7 @@ async def test_hot_water_config(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -90,7 +90,7 @@ async def test_hot_water_config_no_params_error(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
         # Create a mock API validator that returns empty parameters
         mock_validator = MagicMock()
@@ -120,7 +120,7 @@ async def test_hot_water_schedule(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -239,7 +239,7 @@ async def test_hot_water_schedule_no_params_error(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
         # Create a mock API validator that returns empty parameters
         mock_validator = MagicMock()
@@ -269,7 +269,7 @@ async def test_hot_water_state_no_params_error(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
         # Create a mock API validator that returns empty parameters
         mock_validator = MagicMock()
@@ -299,7 +299,7 @@ async def test_granular_hot_water_validation(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -348,7 +348,7 @@ async def test_granular_validation_empty_params(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         # Empty hot_water section in API data
         api_data = {**API_V3, "hot_water": {}}
         monkeypatch.setattr(bsblan, "_api_data", api_data)
@@ -430,7 +430,7 @@ async def test_setup_api_validator_no_api_version() -> None:
         bsblan = BSBLAN(config, session=session)
 
         # No API version set
-        bsblan._api_version = None
+        bsblan._supports_full_config = None
 
         with pytest.raises(BSBLANError, match="API version not set"):
             await bsblan._setup_api_validator()
@@ -446,7 +446,7 @@ async def test_granular_validation_filters_missing_params(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -480,7 +480,7 @@ async def test_granular_validation_filters_invalid_params(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -513,7 +513,7 @@ async def test_ensure_hot_water_group_double_check_after_lock() -> None:
     """Test double-check locking in _ensure_hot_water_group_validated."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {"hot_water": {"1600": "operating_mode"}}  # type: ignore[assignment]
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
@@ -540,7 +540,7 @@ async def test_ensure_hot_water_group_concurrent_double_check() -> None:
     """Test that concurrent hot water group validation doesn't duplicate."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {"hot_water": {"1600": "operating_mode"}}  # type: ignore[assignment]
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 
@@ -578,7 +578,7 @@ async def test_ensure_hot_water_group_validated_with_include_filter() -> None:
     """Test that include filter limits which params are validated."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         # Set up api_data with multiple params in the config group
         bsblan._api_data = {  # type: ignore[assignment]
             "hot_water": {
@@ -629,7 +629,7 @@ async def test_ensure_hot_water_group_validated_include_empty_result() -> None:
     """Test that include filter with no matching params marks group validated."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {  # type: ignore[assignment]
             "hot_water": {
                 "1640": "legionella_function",
@@ -664,7 +664,7 @@ async def test_ensure_hot_water_group_validated_without_include() -> None:
     """Test that without include filter all group params are validated."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._api_data = {  # type: ignore[assignment]
             "hot_water": {
                 "1640": "legionella_function",

--- a/tests/test_hotwater_state.py
+++ b/tests/test_hotwater_state.py
@@ -29,7 +29,7 @@ async def test_hot_water_state(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
         # Create a modified API_V3 excluding the time switch parameters
         test_api_v3: APIConfig = {

--- a/tests/test_include_parameter.py
+++ b/tests/test_include_parameter.py
@@ -52,7 +52,7 @@ async def test_section_method_with_include_single_param(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -106,7 +106,7 @@ async def test_section_method_with_empty_include_list(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -146,7 +146,7 @@ async def test_section_method_with_invalid_params(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -175,7 +175,7 @@ async def test_validate_api_section_with_include_filter(monkeypatch: Any) -> Non
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
         # Set up API data with multiple params
         api_data = {
@@ -257,7 +257,7 @@ async def test_state_with_include_multiple_params(monkeypatch: Any) -> None:
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -292,7 +292,7 @@ async def test_state_include_skips_temperature_unit_warning(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "5.1.0")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
         bsblan._validator._api_validator = APIValidator(API_V3)
 
@@ -322,7 +322,7 @@ async def test_state_with_include_mixed_valid_invalid_params(monkeypatch: Any) -
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -356,7 +356,7 @@ async def test_state_without_include(monkeypatch: Any) -> None:
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -386,7 +386,7 @@ async def test_static_values_with_include(monkeypatch: Any) -> None:
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -477,7 +477,7 @@ async def test_hot_water_method_with_include(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
@@ -542,7 +542,7 @@ async def test_hot_water_method_with_empty_include_list(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
@@ -593,7 +593,7 @@ async def test_hot_water_method_with_invalid_params(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -32,8 +32,8 @@ async def test_info(aresponses: ResponsesMockServer, monkeypatch: Any) -> None:
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        # set _api_version
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        # set the capability flag
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
         # Mock _api_validator with device section params
         mock_validator = MagicMock()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -16,26 +16,15 @@ from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
     ErrorMsg,
 )
-from bsblan.exceptions import BSBLANError, BSBLANVersionError
+from bsblan.exceptions import BSBLANError
 
 
 @pytest.mark.asyncio
-async def test_copy_api_config_rejects_unsupported_version() -> None:
-    """Test _copy_api_config rejects unsupported API versions."""
+async def test_copy_api_config_full() -> None:
+    """Test _copy_api_config when full config is supported."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v1"
-
-        with pytest.raises(BSBLANVersionError):
-            bsblan._copy_api_config()
-
-
-@pytest.mark.asyncio
-async def test_copy_api_config_v3() -> None:
-    """Test _copy_api_config with v3 version."""
-    async with aiohttp.ClientSession() as session:
-        bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
 
         api_data = bsblan._copy_api_config()
 
@@ -49,8 +38,8 @@ async def test_copy_api_config_no_version() -> None:
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
 
-        # Force api_version to None to test error condition
-        bsblan._api_version = None
+        # Force capability flag to None to test error condition
+        bsblan._supports_full_config = None
 
         with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
             bsblan._copy_api_config()
@@ -162,7 +151,7 @@ async def test_setup_api_validator() -> None:
     """Test _setup_api_validator method."""
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
 
         await bsblan._setup_api_validator()
 

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -34,7 +34,7 @@ async def pps_bsblan() -> AsyncGenerator[BSBLAN, None]:
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(config, session=session)
         bsblan._firmware_version = "5.1.0"
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._device = Device.model_validate(
             json.loads(load_fixture("pps_device.json"))
         )
@@ -147,7 +147,7 @@ async def test_time_refreshes_device_when_initialized() -> None:
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._firmware_version = "5.1.0"
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._initialized = True
         request_mock = AsyncMock(
             side_effect=[
@@ -318,7 +318,7 @@ async def test_pps_thermostat_rejects_read_only_bus() -> None:
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
         bsblan._firmware_version = "5.1.0"
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._device = Device(
             name="BSB-LAN",
             version="5.1.0",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -78,7 +78,7 @@ async def test_sensor(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
         api_validator = APIValidator(api_data)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -28,7 +28,7 @@ async def test_state(monkeypatch: Any) -> None:
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -99,7 +99,7 @@ async def test_state_with_cooling_include(monkeypatch: Any) -> None:
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)
@@ -128,7 +128,7 @@ async def test_state_without_cooling_strips_target_temperature_high(
         bsblan = BSBLAN(config, session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         bsblan._api_data = {
             section: params.copy() for section, params in API_V3.items()
         }

--- a/tests/test_static_state.py
+++ b/tests/test_static_state.py
@@ -25,7 +25,7 @@ async def test_sensor(monkeypatch: Any) -> None:
         bsblan = BSBLAN(config=BSBLANConfig(host="example.com"), session=session)
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
-        monkeypatch.setattr(bsblan, "_api_version", "v3")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
         monkeypatch.setattr(bsblan, "_api_data", API_V3)
 
         api_validator = APIValidator(API_V3)

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -149,7 +149,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v3"
+        client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
         source_config = API_V3
         client._api_data = cast(
@@ -186,7 +186,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v3"
+        client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
         source_config = API_V3
         client._api_data = cast(
@@ -222,7 +222,7 @@ async def test_temperature_range_static_values_error(monkeypatch: Any) -> None:
         config = BSBLANConfig(host="example.com")
         client = BSBLAN(config, session=session)
 
-        client._api_version = "v3"
+        client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
         source_config = API_V3
         client._api_data = cast(

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -41,7 +41,7 @@ async def mock_bsblan() -> AsyncGenerator[BSBLAN, None]:
     async with aiohttp.ClientSession() as session:
         bsblan = BSBLAN(config, session=session)
         bsblan._firmware_version = "1.0.38-20200730234859"
-        bsblan._api_version = "v3"
+        bsblan._supports_full_config = True
         bsblan._temperature._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
         bsblan._temperature._circuit_temp_initialized.add(1)
         yield bsblan

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -13,18 +13,18 @@ from bsblan.models import Device
 
 
 @pytest.mark.asyncio
-async def test_set_api_version_without_json_api() -> None:
+async def test_resolve_api_capabilities_without_json_api() -> None:
     """Test that a missing JSON-API version raises BSBLANVersionError."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
     # No JSON-API version available (device did not expose /JV).
     with pytest.raises(BSBLANVersionError):
-        bsblan._set_api_version()
+        bsblan._resolve_api_capabilities()
 
 
 @pytest.mark.asyncio
-async def test_set_api_version_ignores_firmware() -> None:
+async def test_resolve_api_capabilities_ignores_firmware() -> None:
     """Test the firmware version is not used to select the configuration.
 
     Even a modern firmware version cannot stand in for a missing JSON-API
@@ -37,7 +37,7 @@ async def test_set_api_version_ignores_firmware() -> None:
     bsblan._firmware_version = "5.0.16"
 
     with pytest.raises(BSBLANVersionError):
-        bsblan._set_api_version()
+        bsblan._resolve_api_capabilities()
 
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_fetch_firmware_version() -> None:
     with (
         patch.object(bsblan, "device", AsyncMock(return_value=device)),
         patch.object(bsblan, "_fetch_json_api_version", AsyncMock()),
-        patch.object(bsblan, "_set_api_version"),
+        patch.object(bsblan, "_resolve_api_capabilities"),
     ):
         await bsblan._fetch_firmware_version()
 
@@ -69,8 +69,8 @@ async def test_setup_api_validator_no_api_version() -> None:
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
-    # Force API version to None to test the defensive error path
-    bsblan._api_version = None
+    # Force the capability flag to None to test the defensive error path
+    bsblan._supports_full_config = None
 
     with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
         await bsblan._setup_api_validator()
@@ -130,27 +130,27 @@ async def test_process_response_non_jq_endpoint() -> None:
 
 
 @pytest.mark.asyncio
-async def test_json_api_version_v3() -> None:
-    """Test JSON-API version >= 2.0 maps to the full v3 config."""
+async def test_json_api_version_enables_full_config() -> None:
+    """Test JSON-API version >= 2.0 enables the full config."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
     bsblan._json_api_version = "2.0"
-    bsblan._set_api_version()
+    bsblan._resolve_api_capabilities()
 
-    assert bsblan._api_version == "v3"
+    assert bsblan._supports_full_config is True
 
 
 @pytest.mark.asyncio
-async def test_json_api_version_basic_v2() -> None:
-    """Test JSON-API version in [1.0, 2.0) maps to the basic v2 config."""
+async def test_json_api_version_uses_basic_config() -> None:
+    """Test JSON-API version in [1.0, 2.0) uses the basic config."""
     config = BSBLANConfig(host="example.com")
     bsblan = BSBLAN(config)
 
     bsblan._json_api_version = "1.5"
-    bsblan._set_api_version()
+    bsblan._resolve_api_capabilities()
 
-    assert bsblan._api_version == "v2"
+    assert bsblan._supports_full_config is False
 
 
 @pytest.mark.asyncio
@@ -162,7 +162,7 @@ async def test_json_api_version_unsupported() -> None:
     bsblan._json_api_version = "0.9"
 
     with pytest.raises(BSBLANVersionError):
-        bsblan._set_api_version()
+        bsblan._resolve_api_capabilities()
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_json_api_version_invalid_string() -> None:
     bsblan._json_api_version = "not-a-version"
 
     with pytest.raises(BSBLANVersionError):
-        bsblan._set_api_version()
+        bsblan._resolve_api_capabilities()
 
 
 @pytest.mark.asyncio
@@ -186,9 +186,9 @@ async def test_json_api_version_used_regardless_of_firmware() -> None:
     # Firmware is informational only; the JSON-API version drives the result.
     bsblan._firmware_version = "1.0.0"
     bsblan._json_api_version = "2.0"
-    bsblan._set_api_version()
+    bsblan._resolve_api_capabilities()
 
-    assert bsblan._api_version == "v3"
+    assert bsblan._supports_full_config is True
 
 
 @pytest.mark.asyncio
@@ -213,7 +213,7 @@ async def test_version_error_exposes_version() -> None:
     bsblan._json_api_version = "0.9"
 
     with pytest.raises(BSBLANVersionError) as exc_info:
-        bsblan._set_api_version()
+        bsblan._resolve_api_capabilities()
 
     assert exc_info.value.version == "0.9"
 
@@ -294,4 +294,4 @@ async def test_fetch_firmware_version_queries_json_api() -> None:
     assert bsblan._firmware_version == "2.2.3"
     assert bsblan._json_api_version == "2.0"
     # The JSON-API version drives the result; firmware is informational only.
-    assert bsblan._api_version == "v3"
+    assert bsblan._supports_full_config is True


### PR DESCRIPTION
Swap the runtime _api_version string for a _supports_full_config bool capability flag. VersionResolver.resolve_config_version is replaced by supports_full_config, and _set_api_version is renamed to _resolve_api_capabilities. _copy_api_config now selects API_V3/API_V2 from the flag and drops the obsolete version-string membership check. Tests are updated to set the boolean flag and assert capability instead of the v2/v3 label. Constant names (API_V2/API_V3) are intentionally kept for Stage 3.