### PR TITLE
Rename API config profiles to API_FULL/API_BASIC

### DIFF
--- a/src/bsblan/_version.py
+++ b/src/bsblan/_version.py
@@ -14,7 +14,7 @@ from packaging.version import InvalidVersion
 
 from .constants import (
     MIN_SUPPORTED_JSON_API,
-    V3_JSON_API_MINIMUM,
+    V2_JSON_API_MINIMUM,
     ErrorMsg,
 )
 from .exceptions import BSBLANVersionError
@@ -32,18 +32,18 @@ class VersionResolver:
         self,
         *,
         json_api_minimum: str = MIN_SUPPORTED_JSON_API,
-        json_api_v3_minimum: str = V3_JSON_API_MINIMUM,
+        json_api_v2_minimum: str = V2_JSON_API_MINIMUM,
     ) -> None:
         """Initialize the resolver with version policy thresholds.
 
         Args:
             json_api_minimum: Lowest supported JSON-API version.
-            json_api_v3_minimum: JSON-API version at/above which the full
+            json_api_v2_minimum: JSON-API version at/above which the full
                 configuration is used.
 
         """
         self._json_api_minimum = json_api_minimum
-        self._json_api_v3_minimum = json_api_v3_minimum
+        self._json_api_v3_minimum = json_api_v2_minimum
 
     def supports_full_config(self, *, json_api_version: str | None) -> bool:
         """Determine whether the device supports the full configuration.

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -17,8 +17,8 @@ from ._transport import BSBLANTransport
 from ._validation import SectionValidator
 from ._version import VersionResolver
 from .constants import (
-    API_V2,
-    API_V3,
+    API_BASIC,
+    API_FULL,
     APIConfig,
     CircuitConfig,
     ErrorMsg,
@@ -240,7 +240,7 @@ class BSBLAN:
         section validation until the data is needed (lazy loading).
         """
         if self._supports_full_config is None:
-            raise BSBLANError(ErrorMsg.API_VERSION)
+            raise BSBLANError(ErrorMsg.CONFIG_NOT_RESOLVED)
 
         # Initialize API data if not already done
         if self._api_data is None:
@@ -489,8 +489,8 @@ class BSBLAN:
 
         """
         if self._supports_full_config is None:
-            raise BSBLANError(ErrorMsg.API_VERSION)
-        source_config: APIConfig = API_V3 if self._supports_full_config else API_V2
+            raise BSBLANError(ErrorMsg.CONFIG_NOT_RESOLVED)
+        source_config: APIConfig = API_FULL if self._supports_full_config else API_BASIC
         return cast(
             "APIConfig",
             {

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -10,24 +10,13 @@ MIN_CIRCUIT: Final[int] = 1
 MAX_CIRCUIT: Final[int] = 2
 
 
-# API version
-# "v3" is the full configuration for BSB-LAN firmware >= 3.0.0.
-# "v2" is a reduced "basic" configuration for the legacy 2.x firmware branch:
-# a single heating circuit plus essential heating, hot water and sensor params.
-SUPPORTED_API_VERSION: Final[str] = "v3"
-BASIC_API_VERSION: Final[str] = "v2"
-SUPPORTED_API_VERSIONS: Final[tuple[str, ...]] = (
-    BASIC_API_VERSION,
-    SUPPORTED_API_VERSION,
-)
-
 # JSON-API version thresholds (from /JV).
 # The /JV endpoint reports the BSB-LAN JSON-API version (e.g. "2.0"), which is
 # the documented, firmware-independent compatibility signal and the sole input
 # for selecting the API config: a JSON-API version below MIN_SUPPORTED_JSON_API
-# is rejected, the [MIN_SUPPORTED_JSON_API, V3_JSON_API_MINIMUM) range maps to
-# the basic "v2" config, and a version >= V3_JSON_API_MINIMUM maps to the full
-# "v3" config. The adapter firmware version (from /JI) is retrieved for
+# is rejected, the [MIN_SUPPORTED_JSON_API, V3_JSON_API_MINIMUM) range selects
+# the basic single-circuit config, and a version >= V3_JSON_API_MINIMUM selects
+# the full config. The adapter firmware version (from /JI) is retrieved for
 # informational purposes only and is not used to select the config.
 MIN_SUPPORTED_JSON_API: Final[str] = "1.0"
 V3_JSON_API_MINIMUM: Final[str] = "2.0"
@@ -133,12 +122,13 @@ BASE_STATIC_VALUES_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
     "1203": "cooling_reduced_setpoint",
 }
 
-# --- Basic "v2" parameters (legacy 2.x firmware) ---
+# --- Basic configuration parameters ---
 # A deliberately minimal, single-circuit set covering core heating control and
 # the min/max bounds needed for a thermostat. Cooling, boost and circuit 2 are
-# intentionally excluded because they are not reliably available on the legacy
-# firmware branch. Hot water, sensor and device params reuse the shared base
-# sets and are filtered per-section against what the device actually exposes.
+# intentionally excluded because they are not reliably available on devices
+# without full-config support. Hot water, sensor and device params reuse the
+# shared base sets and are filtered per-section against what the device
+# actually exposes.
 BASIC_HEATING_PARAMS: Final[dict[str, str]] = {
     "700": "hvac_mode",
     "710": "target_temperature",
@@ -201,29 +191,22 @@ class CircuitConfig:
     INACTIVE_MARKER: Final[str] = "---"
 
 
-def build_api_config(version: str = SUPPORTED_API_VERSION) -> APIConfig:
-    """Build the API configuration for a supported version.
+def build_api_config(*, full: bool = True) -> APIConfig:
+    """Build the API configuration.
 
     Args:
-        version: The API version to build. ``"v3"`` returns the full
-            configuration; ``"v2"`` returns the reduced single-circuit basic
-            configuration for legacy 2.x firmware.
+        full: When ``True`` (default) return the full multi-circuit
+            configuration. When ``False`` return the reduced single-circuit
+            basic configuration (essential heating, hot water and sensor
+            params) for devices without full-config support.
 
     Returns:
         APIConfig: The complete API configuration.
 
-    Raises:
-        ValueError: If a version other than ``"v2"`` or ``"v3"`` is requested.
-
     """
-    if version not in SUPPORTED_API_VERSIONS:
-        supported = ", ".join(SUPPORTED_API_VERSIONS)
-        msg = f"Only API versions {supported} are supported"
-        raise ValueError(msg)
-
-    if version == BASIC_API_VERSION:
-        # Basic single-circuit config for legacy 2.x firmware. Circuit 2 and
-        # cooling are intentionally empty/omitted.
+    if not full:
+        # Basic single-circuit config. Circuit 2 and cooling are intentionally
+        # empty/omitted.
         return {
             "heating": BASIC_HEATING_PARAMS.copy(),
             "staticValues": BASIC_STATIC_VALUES_PARAMS.copy(),
@@ -248,8 +231,8 @@ def build_api_config(version: str = SUPPORTED_API_VERSION) -> APIConfig:
 
 
 # Pre-built API configurations
-API_V2: Final[APIConfig] = build_api_config(BASIC_API_VERSION)
-API_V3: Final[APIConfig] = build_api_config()
+API_BASIC: Final[APIConfig] = build_api_config(full=False)
+API_FULL: Final[APIConfig] = build_api_config()
 
 
 # Validation constants
@@ -532,7 +515,7 @@ class ErrorMsg:
     NO_SCHEDULE = "No schedule provided."
     VERSION = "Version not supported"
     TEMPERATURE_RANGE = "Temperature range not initialized"
-    API_VERSION = "API version not set"
+    CONFIG_NOT_RESOLVED = "API configuration not resolved"
     MULTI_PARAMETER = "Only one parameter can be set at a time"
     SESSION_NOT_INITIALIZED = "Session not initialized"
     API_DATA_NOT_INITIALIZED = "API data not initialized"

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -19,7 +19,7 @@ MAX_CIRCUIT: Final[int] = 2
 # the full config. The adapter firmware version (from /JI) is retrieved for
 # informational purposes only and is not used to select the config.
 MIN_SUPPORTED_JSON_API: Final[str] = "1.0"
-V3_JSON_API_MINIMUM: Final[str] = "2.0"
+V2_JSON_API_MINIMUM: Final[str] = "2.0"
 
 
 class APIConfig(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from aresponses import ResponsesMockServer
 
 from bsblan import BSBLAN, BSBLANConfig
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ async def mock_bsblan(
         bsblan = BSBLAN(config, session=session)
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
         request_mock: AsyncMock = AsyncMock(return_value={"status": "ok"})
         monkeypatch.setattr(bsblan, "_request", request_mock)
         yield bsblan

--- a/tests/test_api_initialization.py
+++ b/tests/test_api_initialization.py
@@ -7,7 +7,7 @@ import pytest
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_V3,
+    API_FULL,
 )
 from bsblan.exceptions import BSBLANError
 
@@ -39,8 +39,8 @@ async def test_api_data_initialized_from_default_config() -> None:
 
         # Verify API data was initialized (should be a copy, not the same object)
         assert client._api_data is not None
-        # Verify it started with the same keys as API_V3
-        assert set(client._api_data.keys()) == set(API_V3.keys())
+        # Verify it started with the same keys as API_FULL
+        assert set(client._api_data.keys()) == set(API_FULL.keys())
 
 
 @pytest.mark.asyncio
@@ -55,5 +55,5 @@ async def test_copy_api_config_raises_without_version() -> None:
         client._api_data = None
 
         # This should raise BSBLANError
-        with pytest.raises(BSBLANError, match="API version not set"):
+        with pytest.raises(BSBLANError, match="API configuration not resolved"):
             client._copy_api_config()

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -17,7 +17,7 @@ import pytest
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
 from bsblan.constants import (
-    API_V3,
+    API_FULL,
     APIConfig,
     ErrorMsg,
 )
@@ -197,7 +197,7 @@ async def test_validate_section_already_validated(monkeypatch: Any) -> None:
 
         client._supports_full_config = True
         # Deep copy to avoid modifying the shared constant
-        source_config = API_V3
+        source_config = API_FULL
         client._api_data = cast(
             "APIConfig",
             {
@@ -231,7 +231,7 @@ async def test_validation_error_resets_section(monkeypatch: Any) -> None:
 
         client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_V3
+        source_config = API_FULL
         client._api_data = cast(
             "APIConfig",
             {

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -35,7 +35,7 @@ async def mock_bsblan_circuit() -> AsyncGenerator[BSBLAN, None]:
         bsblan = BSBLAN(config, session=session)
         bsblan._firmware_version = "1.0.38-20200730234859"
         bsblan._supports_full_config = True
-        bsblan._api_data = build_api_config("v3")
+        bsblan._api_data = build_api_config()
         bsblan._temperature._circuit_temp_ranges[1] = {"min": 17.0, "max": 23.0}
         bsblan._temperature._circuit_temp_initialized.add(1)
 
@@ -86,7 +86,7 @@ async def test_state_circuit1_default(monkeypatch: Any) -> None:
             "1.0.38-20200730234859",
         )
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        api_data = build_api_config("v3")
+        api_data = build_api_config()
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
         api_validator = APIValidator(api_data)
@@ -122,7 +122,7 @@ async def test_state_circuit2(monkeypatch: Any) -> None:
         monkeypatch.setattr(
             bsblan,
             "_api_data",
-            build_api_config("v3"),
+            build_api_config(),
         )
 
         api_validator = APIValidator(bsblan._api_data)
@@ -163,7 +163,7 @@ async def test_state_circuit2_with_include(monkeypatch: Any) -> None:
         monkeypatch.setattr(
             bsblan,
             "_api_data",
-            build_api_config("v3"),
+            build_api_config(),
         )
 
         api_validator = APIValidator(bsblan._api_data)
@@ -208,7 +208,7 @@ async def test_static_values_circuit2(monkeypatch: Any) -> None:
         monkeypatch.setattr(
             bsblan,
             "_api_data",
-            build_api_config("v3"),
+            build_api_config(),
         )
 
         api_validator = APIValidator(bsblan._api_data)
@@ -474,7 +474,7 @@ async def test_circuit2_temp_range_initialization(
         monkeypatch.setattr(
             bsblan,
             "_api_data",
-            build_api_config("v3"),
+            build_api_config(),
         )
 
         api_validator = APIValidator(bsblan._api_data)
@@ -510,7 +510,7 @@ async def test_circuit1_temp_range_uses_protective_lower_bound(
             "1.0.38-20200730234859",
         )
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        api_data = build_api_config("v3")
+        api_data = build_api_config()
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
         api_validator = APIValidator(api_data)
@@ -552,7 +552,7 @@ async def test_thermostat_circuit2_lazy_temp_init(
         monkeypatch.setattr(
             bsblan,
             "_api_data",
-            build_api_config("v3"),
+            build_api_config(),
         )
 
         api_validator = APIValidator(bsblan._api_data)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,8 +5,8 @@ import pytest
 import bsblan
 import bsblan.constants
 from bsblan.constants import (
-    API_V2,
-    API_V3,
+    API_BASIC,
+    API_FULL,
     BASE_HOT_WATER_PARAMS,
     HeatingCircuitStatus,
     HotWaterParams,
@@ -16,8 +16,8 @@ from bsblan.constants import (
 )
 
 
-def test_build_api_config_defaults_to_v3() -> None:
-    """Test building the supported v3 API config by default."""
+def test_build_api_config_defaults_to_full() -> None:
+    """Test building the full API config by default."""
     config = build_api_config()
 
     expected_includes = {
@@ -41,20 +41,20 @@ def test_build_api_config_defaults_to_v3() -> None:
             | config["device"]
             | config["sensor"]
             | config["hot_water"]
-        ), f"Parameter {param_id} missing in the v3 config"
+        ), f"Parameter {param_id} missing in the full config"
 
     # Check excluded parameters are not included
     for param_id in expected_excludes:
         assert param_id not in (config["heating"] | config["staticValues"]), (
-            f"Parameter {param_id} should not be in the v3 config"
+            f"Parameter {param_id} should not be in the full config"
         )
 
-    assert build_api_config("v3") == config
+    assert build_api_config(full=True) == config
 
 
-def test_build_api_config_v2_is_basic_single_circuit() -> None:
-    """Test the basic v2 config is single-circuit and excludes cooling/boost."""
-    config = build_api_config("v2")
+def test_build_api_config_basic_is_single_circuit() -> None:
+    """Test the basic config is single-circuit and excludes cooling/boost."""
+    config = build_api_config(full=False)
 
     # Core heating control is present.
     assert config["heating"] == {
@@ -77,19 +77,12 @@ def test_build_api_config_v2_is_basic_single_circuit() -> None:
     assert config["staticValues_circuit2"] == {}
     # Hot water and sensors reuse the shared base sets.
     assert config["hot_water"] == BASE_HOT_WATER_PARAMS
-    assert config == API_V2
-
-
-@pytest.mark.parametrize("version", ["v1", "v5"])
-def test_build_api_config_rejects_unsupported_versions(version: str) -> None:
-    """Test that only API v2 and v3 can be built."""
-    with pytest.raises(ValueError, match="Only API versions v2, v3 are supported"):
-        build_api_config(version)
+    assert config == API_BASIC
 
 
 def test_pre_built_api_configuration() -> None:
     """Test that the pre-built API configuration is correct."""
-    all_params = set(API_V3["heating"].keys()) | set(API_V3["staticValues"].keys())
+    all_params = set(API_FULL["heating"].keys()) | set(API_FULL["staticValues"].keys())
 
     for param_id in ("770", "716"):
         assert param_id in all_params

--- a/tests/test_hot_water_additional.py
+++ b/tests/test_hot_water_additional.py
@@ -11,7 +11,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 from bsblan.exceptions import BSBLANError
 from bsblan.models import HotWaterConfig, HotWaterSchedule
 from bsblan.utility import APIValidator
@@ -29,9 +29,9 @@ async def test_hot_water_config(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("hot_water")
         bsblan._validator._api_validator = api_validator
 
@@ -121,9 +121,9 @@ async def test_hot_water_schedule(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("hot_water")
         bsblan._validator._api_validator = api_validator
 
@@ -300,9 +300,9 @@ async def test_granular_hot_water_validation(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         bsblan._validator._api_validator = api_validator
 
         # Mock the request to return valid hot water params
@@ -350,7 +350,7 @@ async def test_granular_validation_empty_params(
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
         # Empty hot_water section in API data
-        api_data = {**API_V3, "hot_water": {}}
+        api_data = {**API_FULL, "hot_water": {}}
         monkeypatch.setattr(bsblan, "_api_data", api_data)
 
         api_validator = APIValidator(api_data)
@@ -424,15 +424,15 @@ async def test_ensure_section_validated_no_validator() -> None:
 
 @pytest.mark.asyncio
 async def test_setup_api_validator_no_api_version() -> None:
-    """Test _setup_api_validator raises error without API version."""
+    """Test _setup_api_validator raises error without a resolved config."""
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
 
-        # No API version set
+        # No config capability resolved
         bsblan._supports_full_config = None
 
-        with pytest.raises(BSBLANError, match="API version not set"):
+        with pytest.raises(BSBLANError, match="API configuration not resolved"):
             await bsblan._setup_api_validator()
 
 
@@ -447,9 +447,9 @@ async def test_granular_validation_filters_missing_params(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         bsblan._validator._api_validator = api_validator
 
         # Mock response that's missing param "1610"
@@ -481,9 +481,9 @@ async def test_granular_validation_filters_invalid_params(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         bsblan._validator._api_validator = api_validator
 
         # Mock response with invalid values

--- a/tests/test_hotwater_state.py
+++ b/tests/test_hotwater_state.py
@@ -12,7 +12,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig, HotWaterState
-from bsblan.constants import API_V3, APIConfig
+from bsblan.constants import API_FULL, APIConfig
 from bsblan.utility import APIValidator
 
 from . import load_fixture
@@ -31,24 +31,24 @@ async def test_hot_water_state(
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
 
-        # Create a modified API_V3 excluding the time switch parameters
-        test_api_v3: APIConfig = {
-            "heating": API_V3["heating"].copy(),
-            "staticValues": API_V3["staticValues"].copy(),
-            "device": API_V3["device"].copy(),
-            "sensor": API_V3["sensor"].copy(),
+        # Create a modified full config excluding the time switch parameters
+        test_api_full: APIConfig = {
+            "heating": API_FULL["heating"].copy(),
+            "staticValues": API_FULL["staticValues"].copy(),
+            "device": API_FULL["device"].copy(),
+            "sensor": API_FULL["sensor"].copy(),
             "hot_water": {
                 k: v
-                for k, v in API_V3["hot_water"].items()
+                for k, v in API_FULL["hot_water"].items()
                 if k not in ["561", "562", "563", "564", "565", "566", "567", "576"]
             },
-            "heating_circuit2": API_V3["heating_circuit2"].copy(),
-            "staticValues_circuit2": API_V3["staticValues_circuit2"].copy(),
+            "heating_circuit2": API_FULL["heating_circuit2"].copy(),
+            "staticValues_circuit2": API_FULL["staticValues_circuit2"].copy(),
         }
 
-        monkeypatch.setattr(bsblan, "_api_data", test_api_v3)
+        monkeypatch.setattr(bsblan, "_api_data", test_api_full)
 
-        api_validator = APIValidator(test_api_v3)
+        api_validator = APIValidator(test_api_full)
         api_validator.validated_sections.add("hot_water")
         bsblan._validator._api_validator = api_validator
 

--- a/tests/test_include_parameter.py
+++ b/tests/test_include_parameter.py
@@ -16,7 +16,7 @@ import pytest
 
 from bsblan import BSBLAN, BSBLANConfig, State, StaticState
 from bsblan.constants import (
-    API_V3,
+    API_FULL,
     ErrorMsg,
 )
 from bsblan.exceptions import BSBLANError
@@ -53,9 +53,9 @@ async def test_section_method_with_include_single_param(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add(section)
         bsblan._validator._api_validator = api_validator
 
@@ -107,9 +107,9 @@ async def test_section_method_with_empty_include_list(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add(section)
         bsblan._validator._api_validator = api_validator
 
@@ -147,9 +147,9 @@ async def test_section_method_with_invalid_params(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add(section)
         bsblan._validator._api_validator = api_validator
 
@@ -258,9 +258,9 @@ async def test_state_with_include_multiple_params(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("heating")
         bsblan._validator._api_validator = api_validator
 
@@ -293,8 +293,8 @@ async def test_state_include_skips_temperature_unit_warning(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "5.1.0")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
-        bsblan._validator._api_validator = APIValidator(API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
+        bsblan._validator._api_validator = APIValidator(API_FULL)
 
         state_data = json.loads(load_fixture("state.json"))
         partial_response = {"700": state_data["700"]}
@@ -323,9 +323,9 @@ async def test_state_with_include_mixed_valid_invalid_params(monkeypatch: Any) -
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("heating")
         bsblan._validator._api_validator = api_validator
 
@@ -357,9 +357,9 @@ async def test_state_without_include(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("heating")
         bsblan._validator._api_validator = api_validator
 
@@ -387,9 +387,9 @@ async def test_static_values_with_include(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("staticValues")
         bsblan._validator._api_validator = api_validator
 
@@ -478,7 +478,7 @@ async def test_hot_water_method_with_include(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
         bsblan._validator._validated_hot_water_groups.add(group_name)
@@ -543,7 +543,7 @@ async def test_hot_water_method_with_empty_include_list(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
         bsblan._validator._validated_hot_water_groups.add(group_name)
@@ -594,7 +594,7 @@ async def test_hot_water_method_with_invalid_params(
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         monkeypatch.setattr(bsblan._validator, "_hot_water_param_cache", param_cache)
         bsblan._validator._validated_hot_water_groups.add(group_name)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -41,7 +41,7 @@ async def test_copy_api_config_no_version() -> None:
         # Force capability flag to None to test error condition
         bsblan._supports_full_config = None
 
-        with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
+        with pytest.raises(BSBLANError, match=ErrorMsg.CONFIG_NOT_RESOLVED):
             bsblan._copy_api_config()
 
 

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -38,7 +38,7 @@ async def pps_bsblan() -> AsyncGenerator[BSBLAN, None]:
         bsblan._device = Device.model_validate(
             json.loads(load_fixture("pps_device.json"))
         )
-        bsblan._api_data = build_api_config("v3")
+        bsblan._api_data = build_api_config()
         bsblan._apply_bus_specific_api_config()
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
         yield bsblan
@@ -327,7 +327,7 @@ async def test_pps_thermostat_rejects_read_only_bus() -> None:
             bus="PPS",
             buswritable=0,
         )
-        bsblan._api_data = build_api_config("v3")
+        bsblan._api_data = build_api_config()
         bsblan._apply_bus_specific_api_config()
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
         request_mock = AsyncMock(return_value={"status": "ok"})

--- a/tests/test_read_parameters.py
+++ b/tests/test_read_parameters.py
@@ -7,7 +7,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig, BSBLANError
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 
 
 @pytest.mark.asyncio
@@ -119,7 +119,7 @@ async def test_get_parameter_id_found(monkeypatch: Any) -> None:
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         # Act
         param_id = bsblan.get_parameter_id("current_temperature")
@@ -134,7 +134,7 @@ async def test_get_parameter_id_not_found(monkeypatch: Any) -> None:
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         # Act
         param_id = bsblan.get_parameter_id("nonexistent_parameter")
@@ -164,7 +164,7 @@ async def test_get_parameter_ids(monkeypatch: Any) -> None:
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         # Act
         result = bsblan.get_parameter_ids(
@@ -188,7 +188,7 @@ async def test_read_parameters_by_name(monkeypatch: Any) -> None:
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         # Mock response
         mock_response = {
@@ -230,7 +230,7 @@ async def test_read_parameters_by_name_empty_list(monkeypatch: Any) -> None:
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         with pytest.raises(BSBLANError, match="No parameter names provided"):
             await bsblan.read_parameters_by_name([])
@@ -254,7 +254,7 @@ async def test_read_parameters_by_name_unknown_names(monkeypatch: Any) -> None:
     async with aiohttp.ClientSession() as session:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
         with pytest.raises(
             BSBLANError,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,7 +12,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig, Sensor
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 from bsblan.utility import APIValidator
 
 from . import load_fixture
@@ -34,8 +34,8 @@ SENSOR_RESPONSE_NO_OUTSIDE_TEMP = {
 }
 
 # API config without outside_temperature parameter
-API_V3_NO_OUTSIDE_TEMP = {
-    **API_V3,
+API_FULL_NO_OUTSIDE_TEMP = {
+    **API_FULL,
     "sensor": {"8740": "current_temperature"},
 }
 
@@ -45,14 +45,14 @@ API_V3_NO_OUTSIDE_TEMP = {
     ("api_data", "sensor_response", "expected_outside_temp", "expected_current_temp"),
     [
         pytest.param(
-            API_V3,
+            API_FULL,
             SENSOR_RESPONSE_FULL,
             {"value": 7.6, "unit": "&deg;C"},
             {"value": 18.2},
             id="with_outside_temperature",
         ),
         pytest.param(
-            API_V3_NO_OUTSIDE_TEMP,
+            API_FULL_NO_OUTSIDE_TEMP,
             SENSOR_RESPONSE_NO_OUTSIDE_TEMP,
             None,
             {"value": 18.2},

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,7 +14,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig, State
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 from bsblan.utility import APIValidator
 
 from . import load_fixture
@@ -29,9 +29,9 @@ async def test_state(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("heating")
         bsblan._validator._api_validator = api_validator
 
@@ -100,9 +100,9 @@ async def test_state_with_cooling_include(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("heating")
         bsblan._validator._api_validator = api_validator
 
@@ -130,7 +130,7 @@ async def test_state_without_cooling_strips_target_temperature_high(
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
         bsblan._api_data = {
-            section: params.copy() for section, params in API_V3.items()
+            section: params.copy() for section, params in API_FULL.items()
         }
         bsblan._validator._api_validator = APIValidator(bsblan._api_data)
 

--- a/tests/test_static_state.py
+++ b/tests/test_static_state.py
@@ -12,7 +12,7 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig, StaticState
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 from bsblan.utility import APIValidator
 
 from . import load_fixture
@@ -26,9 +26,9 @@ async def test_sensor(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
         monkeypatch.setattr(bsblan, "_supports_full_config", True)
-        monkeypatch.setattr(bsblan, "_api_data", API_V3)
+        monkeypatch.setattr(bsblan, "_api_data", API_FULL)
 
-        api_validator = APIValidator(API_V3)
+        api_validator = APIValidator(API_FULL)
         api_validator.validated_sections.add("staticValues")
         bsblan._validator._api_validator = api_validator
 

--- a/tests/test_temperature_validation.py
+++ b/tests/test_temperature_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.constants import API_V3, APIConfig
+from bsblan.constants import API_FULL, APIConfig
 from bsblan.exceptions import BSBLANError, BSBLANInvalidParameterError
 from bsblan.utility import APIValidator
 
@@ -151,7 +151,7 @@ async def test_temperature_range_min_temp_not_available(monkeypatch: Any) -> Non
 
         client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_V3
+        source_config = API_FULL
         client._api_data = cast(
             "APIConfig",
             {
@@ -188,7 +188,7 @@ async def test_temperature_range_max_temp_not_available(monkeypatch: Any) -> Non
 
         client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_V3
+        source_config = API_FULL
         client._api_data = cast(
             "APIConfig",
             {
@@ -224,7 +224,7 @@ async def test_temperature_range_static_values_error(monkeypatch: Any) -> None:
 
         client._supports_full_config = True
         # Copy each section dictionary to avoid modifying the shared constant
-        source_config = API_V3
+        source_config = API_FULL
         client._api_data = cast(
             "APIConfig",
             {

--- a/tests/test_utility_edge_cases.py
+++ b/tests/test_utility_edge_cases.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-from bsblan.constants import API_V3
+from bsblan.constants import API_FULL
 from bsblan.utility import APIValidator
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def test_validate_section_unknown_section(caplog: pytest.LogCaptureFixture) -> None:
     """Test validation of an unknown section logs warning and returns."""
-    api_validator = APIValidator(API_V3)
+    api_validator = APIValidator(API_FULL)
 
     # Mock the api_config to not have the section we're testing
     api_validator.api_config = MagicMock()
@@ -33,7 +33,7 @@ def test_validate_section_unknown_section(caplog: pytest.LogCaptureFixture) -> N
 
 def test_validate_section_already_validated(caplog: pytest.LogCaptureFixture) -> None:
     """Test validation of an already validated section logs debug and returns."""
-    api_validator = APIValidator(API_V3)
+    api_validator = APIValidator(API_FULL)
 
     # Add section to validated_sections first
     api_validator.validated_sections.add("hot_water")

--- a/tests/test_version_errors.py
+++ b/tests/test_version_errors.py
@@ -72,7 +72,7 @@ async def test_setup_api_validator_no_api_version() -> None:
     # Force the capability flag to None to test the defensive error path
     bsblan._supports_full_config = None
 
-    with pytest.raises(BSBLANError, match=ErrorMsg.API_VERSION):
+    with pytest.raises(BSBLANError, match=ErrorMsg.CONFIG_NOT_RESOLVED):
         await bsblan._setup_api_validator()
 
 


### PR DESCRIPTION
This pull request refactors the API configuration versioning system in the `bsblan` project to use clearer, more descriptive identifiers (`API_BASIC`, `API_FULL`) instead of version numbers (`API_V2`, `API_V3`). It also updates error messages for better clarity and simplifies the API configuration building logic. All usages in the codebase and tests are updated accordingly.

**API configuration refactor:**

* Replaces `API_V2`/`API_V3` constants and terminology with `API_BASIC`/`API_FULL` throughout the codebase and tests for improved clarity. (`src/bsblan/constants.py`, `src/bsblan/bsblan.py`, `tests/conftest.py`, `tests/test_api_initialization.py`, `tests/test_api_validation.py`, `tests/test_circuit.py`, `tests/test_constants.py`, `tests/test_hot_water_additional.py`) [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L20-R21) [[2]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L492-R493) [[3]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL13-R19) [[4]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL251-R235) [[5]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L13-R13) [[6]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL10-R10) [[7]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L20-R20) [[8]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L38-R38) [[9]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL8-R9) [[10]](diffhunk://#diff-1cbdab693bcb90edcf11abecc8ed4d8b77f5c33bd2503fdb127504c88283692aL14-R14) [[11]](diffhunk://#diff-1cbdab693bcb90edcf11abecc8ed4d8b77f5c33bd2503fdb127504c88283692aL32-R34) [[12]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L200-R200) [[13]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L234-R234) [[14]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L89-R89) [[15]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L125-R125) [[16]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L166-R166) [[17]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L211-R211) [[18]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L477-R477) [[19]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L513-R513) [[20]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L555-R555) [[21]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL19-R20) [[22]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL44-R57) [[23]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL80-R85) [[24]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL42-R43) [[25]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL58-R58) [[26]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L38-R38)

* Refactors the `build_api_config` function to use a `full: bool` parameter instead of version strings, removing support for version-based configuration selection and simplifying its interface. (`src/bsblan/constants.py`)

**Error handling improvements:**

* Updates error messages and exception handling to use more descriptive text, such as replacing `"API version not set"` with `"API configuration not resolved"`. (`src/bsblan/constants.py`, `src/bsblan/bsblan.py`, `tests/test_api_initialization.py`) [[1]](diffhunk://#diff-2f3166e80717cf524a9e2c8b94ee5aa4f58038415bd28ed8cca138da80840428L243-R243) [[2]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL535-R518) [[3]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL58-R58)

**Documentation and comments:**

* Updates comments and docstrings to reflect the new terminology and clarify the distinction between basic and full configurations, removing references to legacy version numbers. (`src/bsblan/constants.py`) [[1]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL136-R131) [[2]](diffhunk://#diff-0b8206ed25da1b455f42c83f9794091973c966491887a81a21517205e2f444bdL13-R19)

**Test updates:**

* Refactors all tests to use the new `API_BASIC`/`API_FULL` constants and the updated `build_api_config` interface, ensuring consistency and removing version-based test logic. (`tests/conftest.py`, `tests/test_api_initialization.py`, `tests/test_api_validation.py`, `tests/test_circuit.py`, `tests/test_constants.py`, `tests/test_hot_water_additional.py`) [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L13-R13) [[2]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL10-R10) [[3]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L20-R20) [[4]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L38-R38) [[5]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL8-R9) [[6]](diffhunk://#diff-1cbdab693bcb90edcf11abecc8ed4d8b77f5c33bd2503fdb127504c88283692aL14-R14) [[7]](diffhunk://#diff-1cbdab693bcb90edcf11abecc8ed4d8b77f5c33bd2503fdb127504c88283692aL32-R34) [[8]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L200-R200) [[9]](diffhunk://#diff-3978aa52b9e85c5b0bdbdf4fbb7e619a967b0c4e4308e308c26f0c243a08fcf0L234-R234) [[10]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L89-R89) [[11]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L125-R125) [[12]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L166-R166) [[13]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L211-R211) [[14]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L477-R477) [[15]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L513-R513) [[16]](diffhunk://#diff-c93ecb5bf8e16a8a6a058d01f46de5af60cf2b3ce06c57808066f2bcb6ded364L555-R555) [[17]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL19-R20) [[18]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL44-R57) [[19]](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eL80-R85) [[20]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL42-R43) [[21]](diffhunk://#diff-526f2f5df016b469075e3a066c2b1c4188bf179f0ec085d44b8f0ca3be35025aL58-R58) [[22]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L38-R38)

These changes make the API configuration system more maintainable and easier to understand, and improve the clarity of error handling and documentation.