### PR TITLE
Add handling for JSON-API version 1.0 in circuit discovery

### DIFF
--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -189,6 +189,13 @@ class BSBLAN:
         """
         if self._uses_pps_bus:
             return await self._get_available_pps_circuits()
+        if self._json_api_version == "1.0":
+            logger.debug(
+                "BSBLAN JSON-API version 1.0 detected; skipping circuit discovery and "
+                "assuming only circuit 1 is available"
+            )
+            self._available_circuits = {1}
+            return [1]
 
         available: list[int] = []
         for circuit, param_id in CircuitConfig.PROBE_PARAMS.items():

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -187,8 +187,6 @@ class BSBLAN:
                 # circuits == [1, 2] for a dual-circuit controller
 
         """
-        if self._uses_pps_bus:
-            return await self._get_available_pps_circuits()
         if self._json_api_version == "1.0":
             logger.debug(
                 "BSBLAN JSON-API version 1.0 detected; skipping circuit discovery and "
@@ -196,6 +194,8 @@ class BSBLAN:
             )
             self._available_circuits = {1}
             return [1]
+        if self._uses_pps_bus:
+            return await self._get_available_pps_circuits()
 
         available: list[int] = []
         for circuit, param_id in CircuitConfig.PROBE_PARAMS.items():

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -19,6 +19,7 @@ from ._version import VersionResolver
 from .constants import (
     API_BASIC,
     API_FULL,
+    MIN_SUPPORTED_JSON_API,
     APIConfig,
     CircuitConfig,
     ErrorMsg,
@@ -187,7 +188,7 @@ class BSBLAN:
                 # circuits == [1, 2] for a dual-circuit controller
 
         """
-        if self._json_api_version == "1.0":
+        if self._json_api_version == MIN_SUPPORTED_JSON_API:
             logger.debug(
                 "BSBLAN JSON-API version 1.0 detected; skipping circuit discovery and "
                 "assuming only circuit 1 is available"

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -784,7 +784,7 @@ async def test_get_available_circuits_json_api_v1_skips_discovery(
 
     assert circuits == [1]
     assert bsblan._available_circuits == {1}
-    request_mock.assert_not_called()
+    request_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -13,7 +13,12 @@ import pytest
 from aresponses import Response, ResponsesMockServer
 
 from bsblan import BSBLAN, BSBLANConfig, State, StaticState
-from bsblan.constants import CircuitConfig, ErrorMsg, build_api_config
+from bsblan.constants import (
+    MIN_SUPPORTED_JSON_API,
+    CircuitConfig,
+    ErrorMsg,
+    build_api_config,
+)
 from bsblan.exceptions import BSBLANError, BSBLANInvalidParameterError
 from bsblan.utility import APIValidator
 
@@ -775,7 +780,7 @@ async def test_get_available_circuits_json_api_v1_skips_discovery(
 ) -> None:
     """Test that JSON-API version 1.0 skips circuit discovery and returns [1]."""
     bsblan = mock_bsblan_circuit
-    bsblan._json_api_version = "1.0"
+    bsblan._json_api_version = MIN_SUPPORTED_JSON_API
 
     request_mock = AsyncMock()
     bsblan._request = request_mock  # type: ignore[method-assign]

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -770,6 +770,24 @@ async def test_get_available_circuits_all_probes_missing(
 
 
 @pytest.mark.asyncio
+async def test_get_available_circuits_json_api_v1_skips_discovery(
+    mock_bsblan_circuit: BSBLAN,
+) -> None:
+    """Test that JSON-API version 1.0 skips circuit discovery and returns [1]."""
+    bsblan = mock_bsblan_circuit
+    bsblan._json_api_version = "1.0"
+
+    request_mock = AsyncMock()
+    bsblan._request = request_mock  # type: ignore[method-assign]
+
+    circuits = await bsblan.get_available_circuits()
+
+    assert circuits == [1]
+    assert bsblan._available_circuits == {1}
+    request_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_temperature_range_skips_unavailable_discovered_circuit(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:


### PR DESCRIPTION
This pull request updates the circuit discovery logic to properly handle BSBLAN devices using JSON-API version 1.0, and adds a test to ensure this behavior. When version 1.0 is detected, the code now skips circuit discovery and assumes only circuit 1 is available.

Behavior changes for JSON-API version 1.0:

* Updated `get_available_circuits` in `bsblan.py` to detect JSON-API version 1.0, skip circuit discovery, and return `[1]` as the available circuit, also setting the internal `_available_circuits` to `{1}`.

Testing improvements:

* Added a new asynchronous test in `test_circuit.py` to verify that when the JSON-API version is 1.0, circuit discovery is skipped, `[1]` is returned, and no requests are made to the device.