### PR TITLE
Improve circuit operating mode validation for None and invalid values

### DIFF
--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -212,8 +212,9 @@ class BSBLAN:
                 continue
 
             # A circuit exists if the response contains the operating mode key
-            # with actual data (not an empty dict).
-            if not response.get(param_id):
+            # with a valid value (not an empty dict, and not None/"---").
+            param_data = response.get(param_id)
+            if not param_data or param_data.get("value") in (None, "---"):
                 logger.debug(
                     "Circuit %d has no operating mode data (not supported)",
                     circuit,
@@ -236,6 +237,11 @@ class BSBLAN:
 
         if not response.get(param_id):
             logger.debug("PPS climate circuit has no operating mode data")
+            self._available_circuits = set()
+            return []
+        param_data = response[param_id]
+        if param_data.get("value") in (None, "---"):
+            logger.debug("PPS climate circuit has invalid operating mode value")
             self._available_circuits = set()
             return []
         self._available_circuits = {1}

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -775,6 +775,59 @@ async def test_get_available_circuits_all_probes_missing(
 
 
 @pytest.mark.asyncio
+async def test_get_available_circuits_inactive_marker_excludes_circuit(
+    mock_bsblan_circuit: BSBLAN,
+) -> None:
+    """Test a circuit whose probe value is "---" is excluded."""
+    bsblan = mock_bsblan_circuit
+
+    async def mock_request(
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        params = kwargs.get("params", {})
+        param_id = params.get("Parameter", "")
+        if param_id == "700":
+            return {"700": {"value": "1", "unit": "", "desc": "Automatic"}}
+        # HC2 reports the inactive marker value
+        if param_id == "1000":
+            return {"1000": {"value": "---", "unit": "", "desc": ""}}
+        msg = f"Unexpected parameter probe: {param_id}"
+        raise AssertionError(msg)
+
+    bsblan._request = AsyncMock(side_effect=mock_request)  # type: ignore[method-assign]
+
+    circuits = await bsblan.get_available_circuits()
+    assert circuits == [1]
+    assert bsblan._available_circuits == {1}
+
+
+@pytest.mark.asyncio
+async def test_get_available_circuits_none_value_excludes_circuit(
+    mock_bsblan_circuit: BSBLAN,
+) -> None:
+    """Test a circuit whose probe value is None is excluded."""
+    bsblan = mock_bsblan_circuit
+
+    async def mock_request(
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        params = kwargs.get("params", {})
+        param_id = params.get("Parameter", "")
+        if param_id == "700":
+            return {"700": {"value": "1", "unit": "", "desc": "Automatic"}}
+        if param_id == "1000":
+            return {"1000": {"value": None, "unit": "", "desc": ""}}
+        msg = f"Unexpected parameter probe: {param_id}"
+        raise AssertionError(msg)
+
+    bsblan._request = AsyncMock(side_effect=mock_request)  # type: ignore[method-assign]
+
+    circuits = await bsblan.get_available_circuits()
+    assert circuits == [1]
+    assert bsblan._available_circuits == {1}
+
+
+@pytest.mark.asyncio
 async def test_get_available_circuits_json_api_v1_skips_discovery(
     mock_bsblan_circuit: BSBLAN,
 ) -> None:

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -357,12 +357,20 @@ async def test_pps_circuit_discovery_returns_single_climate(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("response", [{}, {"15000": {}}])
+@pytest.mark.parametrize(
+    "response",
+    [
+        {},
+        {"15000": {}},
+        {"15000": {"value": "---", "unit": "", "desc": ""}},
+        {"15000": {"value": None, "unit": "", "desc": ""}},
+    ],
+)
 async def test_pps_circuit_discovery_returns_empty_without_mode(
     pps_bsblan: BSBLAN,
     response: dict[str, Any],
 ) -> None:
-    """Test PPS circuit discovery handles missing operating mode data."""
+    """Test PPS circuit discovery handles missing or inactive mode data."""
     pps_bsblan._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
 
     circuits = await pps_bsblan.get_available_circuits()


### PR DESCRIPTION
This pull request improves the validation logic for determining available circuits by ensuring that circuits with invalid or missing operating mode values are correctly excluded. The changes enhance reliability by explicitly checking for invalid values, not just missing data.

Validation improvements for circuit availability:

* Updated `get_available_circuits` in `bsblan.py` to exclude circuits whose operating mode value is `None` or `"---"`, in addition to empty or missing data.
* Updated `_get_available_pps_circuits` in `bsblan.py` to check for invalid operating mode values (`None` or `"---"`) and handle them by clearing available circuits and returning an empty list.