### PR TITLE
fix: guard section params before validator setup

### DIFF
--- a/src/bsblan/_validation.py
+++ b/src/bsblan/_validation.py
@@ -96,6 +96,9 @@ class SectionValidator:
             dict[str, str]: Mapping of parameter id to parameter name.
 
         """
+        if not self._api_validator:
+            raise BSBLANError(ErrorMsg.API_VALIDATOR_NOT_INITIALIZED)
+
         return cast("APIValidator", self._api_validator).get_section_params(section)
 
     def apply_bus_specific_api_config(

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -90,6 +90,18 @@ async def test_validate_api_section_no_validator() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_section_params_no_validator() -> None:
+    """Test section parameter lookup with no validator initialized."""
+    async with aiohttp.ClientSession() as session:
+        bsblan = BSBLAN(BSBLANConfig(host="example.com"), session=session)
+
+        bsblan._validator._api_validator = None
+
+        with pytest.raises(BSBLANError, match=ErrorMsg.API_VALIDATOR_NOT_INITIALIZED):
+            bsblan._validator.get_section_params("device")
+
+
+@pytest.mark.asyncio
 async def test_validate_api_section_no_api_data() -> None:
     """Test API section validation with no API data initialized."""
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## Summary
- raise `BSBLANError(API_VALIDATOR_NOT_INITIALIZED)` when `SectionValidator.get_section_params()` is called before setup
- add regression coverage for the uninitialized lookup path

Fixes #1521.

## Tests
- `uv run pytest --no-cov tests/test_api_validation.py -k 'get_section_params_no_validator or validate_api_section_no_validator'`\n- `uv run pytest --no-cov tests/test_api_validation.py`\n- `uv run prek run --all-files`