### PR TITLE
Add cooling support

### DIFF
--- a/.github/hooks/run_validation_after_edits.sh
+++ b/.github/hooks/run_validation_after_edits.sh
@@ -6,31 +6,25 @@ payload="$(cat)"
 should_run="$(HOOK_PAYLOAD="$payload" python3 - <<'PY'
 import json
 import os
-import sys
 
-edit_tool_tokens = {
+edit_tools = {
     "edit",
     "write",
     "multi_edit",
     "multiedit",
     "apply_patch",
     "create_file",
+    "insert_edit_into_file",
+    "replace_string_in_file",
+    "multi_replace_string_in_file",
     "edit_notebook_file",
     "create_new_jupyter_notebook",
     "mcp_github_create_or_update_file",
     "mcp_io_github_git_create_or_update_file",
 }
 
-def walk(value):
-    if isinstance(value, dict):
-        for key, item in value.items():
-            yield str(key)
-            yield from walk(item)
-    elif isinstance(value, list):
-        for item in value:
-            yield from walk(item)
-    elif isinstance(value, str):
-        yield value
+# File extensions that require running the Python validation suite.
+code_suffixes = (".py", ".toml", ".cfg", ".ini", ".yaml", ".yml", ".json")
 
 raw = os.environ.get("HOOK_PAYLOAD", "").strip()
 if not raw:
@@ -43,11 +37,37 @@ except json.JSONDecodeError:
     print("skip")
     raise SystemExit(0)
 
-haystack = "\n".join(s.lower() for s in walk(data))
-if any(token in haystack for token in edit_tool_tokens):
-    print("run")
-else:
+tool_name = str(data.get("tool_name") or data.get("toolName") or "").lower()
+if tool_name not in edit_tools:
     print("skip")
+    raise SystemExit(0)
+
+
+def paths(value):
+    """Yield path-like strings from tool input."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"filePath", "file_path", "path", "notebookPath"} and isinstance(
+                item, str
+            ):
+                yield item
+            else:
+                yield from paths(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from paths(item)
+
+
+tool_input = data.get("tool_input") or data.get("toolInput") or {}
+edited = list(paths(tool_input))
+
+# Only run the heavy validation when code/config files were touched.
+# Docs, markdown, and memory edits do not need pytest + prek.
+if edited and not any(p.lower().endswith(code_suffixes) for p in edited):
+    print("skip")
+    raise SystemExit(0)
+
+print("run")
 PY
 )"
 
@@ -64,7 +84,7 @@ if ! uv run pytest --no-cov; then
 fi
 
 echo "[hook] Running prek"
-if ! uv run prek run --all-files; then
+if ! SKIP=no-commit-to-branch uv run prek run --all-files; then
     echo "[hook] Prek failed"
     exit 2
 fi

--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,152 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,157 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,171 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,106 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/prompts/opsx-sync.prompt.md
+++ b/.github/prompts/opsx-sync.prompt.md
@@ -1,0 +1,140 @@
+---
+description: Sync delta specs from a change to main specs
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-sync-specs/SKILL.md
+++ b/.github/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ JSON-API version reported by the `/JV` endpoint:
 
 - **Full configuration** — JSON-API version 2.0 or newer. All features are
   available: multiple heating circuits, hot water control, schedules, sensors,
-  and cooling setpoints.
+  and cooling setpoints and operating mode.
 - **Basic configuration** — JSON-API version 1.x. A reduced, single-circuit
   configuration covering essential heating, hot water, and sensor parameters.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,7 +138,7 @@ support by checking whether `state.cooling_operating_mode` is present.
 
 ```python
 async with BSBLAN(config) as client:
-    state = await client.state(include=["cooling_operating_mode"])
+    state = await client.state(include=["hvac_mode", "cooling_operating_mode"])
 
     if state.cooling_operating_mode is not None:
         print(f"Cooling mode: {state.cooling_operating_mode.desc}")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,6 +124,29 @@ BSB-LAN writes one parameter at a time. If an application exposes a heat/cool
 temperature range, write `target_temperature` and `target_temperature_high` with
 separate `thermostat()` calls.
 
+## Cooling operating mode
+
+The cooling circuit has its own operating mode, separate from the heating
+`hvac_mode` (`700`/`1000`) and the read-only changeover status (`900`/`1200`).
+The client maps BSB-LAN parameter `901` for circuit 1 and `1201` for circuit 2
+to `cooling_operating_mode`. Valid values are `0` (Protection), `1`
+(Automatic), `2` (Reduced), and `3` (Comfort).
+
+Like the cooling setpoint, the parameter is optional and removed from the
+active API map when the device does not expose it, so integrations can detect
+support by checking whether `state.cooling_operating_mode` is present.
+
+```python
+async with BSBLAN(config) as client:
+    state = await client.state(include=["cooling_operating_mode"])
+
+    if state.cooling_operating_mode is not None:
+        print(f"Cooling mode: {state.cooling_operating_mode.desc}")
+        await client.thermostat(cooling_operating_mode=1)
+```
+
+Setting `cooling_operating_mode` is not supported on PPS devices.
+
 ## PPS bus support
 
 PPS bus devices are detected from the device metadata returned by BSB-LAN. The

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,8 @@ Asynchronous Python client for [BSB-LAN](https://github.com/fredlcore/bsb_lan) d
 - Async/await support using `aiohttp`
 - Read heating state, sensor data, and device information
 - Control thermostat settings and hot water parameters
-- Detect optional cooling setpoints for heat/cool range controls
+- Detect optional cooling setpoints and cooling operating mode for
+  heat/cool controls
 - Fully typed with PEP 561 support
 - Full parameter support, plus basic support for JSON-API 1.x devices
 - Automatic capability detection via the BSB-LAN JSON-API (`/JV`)

--- a/examples/control.py
+++ b/examples/control.py
@@ -135,6 +135,7 @@ def print_state(state: State) -> None:
         "HVAC Action (category)": hvac_action_mapped,
         "HVAC Mode": get_attribute(state.hvac_mode, "desc", "Unknown Mode"),
         "Mode Changeover": get_attribute(state.hvac_mode_changeover, "desc"),
+        "Cooling Operating Mode": get_attribute(state.cooling_operating_mode, "desc"),
         "Target Temperature (heating)": get_attribute(state.target_temperature),
         "Cooling Setpoint (target high)": get_attribute(state.target_temperature_high),
         "Current Temperature": get_attribute(state.current_temperature),

--- a/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/.openspec.yaml
@@ -1,0 +1,3 @@
+---
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/design.md
+++ b/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/design.md
@@ -1,0 +1,43 @@
+# Design: add-cooling-operating-mode
+
+## Context
+
+BSB-LAN param `901` (CC1) / `1201` (CC2) is the cooling circuit operating mode — the on/off/auto control for cooling, separate from heating `hvac_mode` (`700`/`1000`) and the read-only changeover status (`900`/`1200`, already mapped). Verified present on a real RVS21.831F device. The library reads heating-section params through the lazily validated `APIConfig` sections and writes via `thermostat()`, which resolves parameter IDs per circuit from `CircuitConfig.THERMOSTAT_PARAMS` and sends one `/JS` request per populated argument.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Read `cooling_operating_mode` as part of `state()` for both circuits (full config).
+- Set it via `thermostat(cooling_operating_mode=...)` for circuits 1 and 2.
+- Validate values client-side before sending.
+
+**Non-Goals:**
+
+- Basic (single-circuit) config and PPS bus support — cooling is deliberately excluded from those profiles.
+- Home Assistant integration changes (downstream; this only unblocks them).
+- Any changes to changeover (`900`/`1200`) or cooling setpoints (`902`/`1202`) behavior.
+
+## Decisions
+
+1. **Naming: `cooling_operating_mode`** (not `cooling_hvac_mode`). It matches the BSB-LAN label "Operating mode" and avoids implying it is a full HVAC mode; follows the existing `operating_mode` precedent in hot-water params. Alternative `hvac_mode_cooling` rejected — the `hvac_mode*` prefix family is reserved for the heating/changeover trio.
+
+2. **Read path: add to heating sections.** `"901": "cooling_operating_mode"` in `BASE_HEATING_PARAMS`, `"1201"` in `BASE_HEATING_CIRCUIT2_PARAMS`. Per-section validation already drops parameters absent on a device (same mechanism as boost `770`/`1070`), so heat-only devices degrade gracefully. Not added to `BASIC_HEATING_PARAMS` or `PPS_HEATING_PARAMS`.
+
+3. **Model type: follow real-device raw data.** First implementation step queries `901` via `examples/fetch_param.py`. Expected: enum with integer value (like `700`) → `EntityInfo[int] | None`. If `data_type` turns out unknown/ambiguous, fall back to `EntityInfo[str] | None` per repo convention. Field is optional so existing fixtures stay valid.
+
+4. **Write path: extend `thermostat()`.** Add optional `cooling_operating_mode: int | None = None`; add `"cooling_operating_mode": "901"` / `"1201"` to `CircuitConfig.THERMOSTAT_PARAMS`. Reuses the existing one-`/JS`-per-parameter loop and `_set_payload` helper, and joins the existing `_validate_single_parameter` contract (exactly one thermostat parameter per call). Alternative — a separate `cooling()` method — rejected: `thermostat()` is the established multi-parameter setter and HA calls it already.
+
+5. **PPS guard.** `_get_pps_thermostat_params()` has no cooling entry; if `cooling_operating_mode` is passed while on PPS bus, raise `BSBLANInvalidParameterError` (explicit, instead of silent `KeyError`).
+
+6. **Validation: dedicated value set.** New `Validation.COOLING_OPERATING_MODES` constant checked in a `_validate_cooling_operating_mode` step mirroring `_validate_hvac_mode`. The exact enum values must be read from the device raw response (`possibleValues`); do not reuse `HVAC_MODES = {0,1,2,3}` blindly.
+
+## Risks / Trade-offs
+
+- [Enum values unconfirmed until device query] → First task fetches raw data for `901`/`1201`; constants set from evidence, not guesses.
+- [Setter usable on basic-config devices where `901` may not exist] → Parity with existing behavior for `902` (`target_temperature_high`): the device rejects unknown params; no extra capability guard added. Documented limitation.
+- [HC2 values return `"---"` on devices with nothing connected] → Already handled by `is_param_value_active`-style probe/validation logic; read simply omits the field.
+
+## Open Questions
+
+- ~~Exact `possibleValues` for `901`~~ **Resolved 2026-07-02** via `/JC` on real device (RVS21.831F): both `901` and `1201` are writable ENUMs with `0=Protection, 1=Automatic, 2=Reduced, 3=Comfort` (same set as heating `hvac_mode`). Values returned as strings (`"3"`) with `dataType: 1` → model type `EntityInfo[int] | None`; valid set `{0, 1, 2, 3}`.

--- a/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/proposal.md
+++ b/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: add-cooling-operating-mode
+
+## Why
+
+BSB-LAN exposes a separate operating mode for the cooling circuit (parameter `901` for circuit 1, `1201` for circuit 2), distinct from the heating operating mode (`700`/`1000`) and the heating/cooling changeover status (`900`/`1200`). The library currently has no read or write support for it, which blocks Home Assistant from offering an explicit COOL HVAC mode — users can read cooling setpoints (`902`/`1202`) but cannot see or control whether cooling is enabled.
+
+## What Changes
+
+- Add parameter mapping `901` → `cooling_operating_mode` (circuit 1) and `1201` → `cooling_operating_mode` (circuit 2) to the full API configuration (heating sections).
+- Add `cooling_operating_mode` field to the `State` response model.
+- Extend the `thermostat()` setter to accept a `cooling_operating_mode` argument, sending one `/JS` request per populated parameter (existing convention), for both circuits.
+- Validate the accepted value range for `901`/`1201` before sending (verified against real-device raw data via `examples/fetch_param.py`).
+- Excluded from scope: the basic (single-circuit) configuration and PPS bus — cooling is intentionally not part of those profiles.
+
+## Capabilities
+
+### New Capabilities
+
+- `cooling-operating-mode`: Reading and setting the cooling circuit operating mode (params `901`/`1201`) through the state model and the thermostat setter, scoped to the full API configuration.
+
+### Modified Capabilities
+
+<!-- No existing specs in openspec/specs/ — nothing to modify. -->
+
+## Impact
+
+- `src/bsblan/constants.py`: `BASE_HEATING_PARAMS`, `BASE_HEATING_CIRCUIT2_PARAMS`, `CircuitConfig.THERMOSTAT_PARAMS`, validation constants for the new value range.
+- `src/bsblan/models.py`: `State` model gains `cooling_operating_mode`.
+- `src/bsblan/bsblan.py`: `thermostat()` signature and set logic, parameter validation.
+- `tests/`: new/extended tests for state read, setter, and validation (coverage gates: total ≥ 95%, patch 100%).
+- Docs: README + docs feature listing per repo convention.
+- No breaking changes; new field/argument are optional.

--- a/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/specs/cooling-operating-mode/spec.md
+++ b/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/specs/cooling-operating-mode/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: State exposes cooling operating mode
+The `State` model SHALL include an optional `cooling_operating_mode` field populated from BSB-LAN parameter `901` (circuit 1) or `1201` (circuit 2) when the full API configuration is active and the device reports the parameter.
+
+#### Scenario: Read cooling operating mode for circuit 1
+- **WHEN** `state()` is called on a full-config device that exposes parameter `901`
+- **THEN** the returned `State.cooling_operating_mode` contains the parameter's name, value, and unit
+
+#### Scenario: Read cooling operating mode for circuit 2
+- **WHEN** `state(circuit=2)` is called on a full-config device that exposes parameter `1201`
+- **THEN** the returned `State.cooling_operating_mode` reflects parameter `1201`
+
+#### Scenario: Device without cooling support
+- **WHEN** `state()` is called on a device where parameter `901` is absent or inactive (`"---"`)
+- **THEN** section validation drops the parameter and `State.cooling_operating_mode` is `None`
+- **AND** no error is raised
+
+#### Scenario: Basic configuration excludes cooling
+- **WHEN** the client resolves the basic (single-circuit) configuration
+- **THEN** parameter `901` is not requested and `State.cooling_operating_mode` is `None`
+
+### Requirement: Thermostat can set cooling operating mode
+The `thermostat()` method SHALL accept an optional `cooling_operating_mode` argument and send it as a single `/JS` request to parameter `901` (circuit 1) or `1201` (circuit 2).
+
+#### Scenario: Set cooling operating mode for circuit 1
+- **WHEN** `thermostat(cooling_operating_mode=1)` is called
+- **THEN** the client sends one `/JS` request with `Parameter` `901`, `Value` `"1"`, and `Type` `"1"`
+
+#### Scenario: Set cooling operating mode for circuit 2
+- **WHEN** `thermostat(cooling_operating_mode=0, circuit=2)` is called
+- **THEN** the client sends one `/JS` request targeting parameter `1201`
+
+#### Scenario: Only one thermostat parameter per call
+- **WHEN** `thermostat(hvac_mode=3, cooling_operating_mode=1)` is called
+- **THEN** `BSBLANError` is raised (existing single-parameter contract)
+- **AND** no HTTP request is sent
+
+### Requirement: Cooling operating mode values are validated
+The client SHALL validate `cooling_operating_mode` against the set of values supported by the device parameter (confirmed from real-device raw data) before sending, and SHALL raise `BSBLANInvalidParameterError` for values outside that set.
+
+#### Scenario: Invalid value rejected
+- **WHEN** `thermostat(cooling_operating_mode=99)` is called
+- **THEN** `BSBLANInvalidParameterError` is raised
+- **AND** no HTTP request is sent
+
+### Requirement: Cooling operating mode is unavailable on PPS bus
+The client SHALL raise `BSBLANInvalidParameterError` when `cooling_operating_mode` is passed to `thermostat()` while the device operates on the PPS bus.
+
+#### Scenario: PPS device rejects cooling operating mode
+- **WHEN** the device uses the PPS bus and `thermostat(cooling_operating_mode=1)` is called
+- **THEN** `BSBLANInvalidParameterError` is raised
+- **AND** no HTTP request is sent

--- a/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/tasks.md
+++ b/openspec/changes/archive/2026-07-03-add-cooling-operating-mode/tasks.md
@@ -1,0 +1,33 @@
+## 1. Device Verification
+
+- [x] 1.1 Query raw data for params `901` and `1201` with `examples/fetch_param.py` on the real device; record `data_type`, value, unit, and `possibleValues`
+- [x] 1.2 Finalize the valid value set and model type (`EntityInfo[int]` vs `EntityInfo[str]`) from the evidence; update design.md Open Questions
+
+## 2. Constants
+
+- [x] 2.1 Add `"901": "cooling_operating_mode"` to `BASE_HEATING_PARAMS` and `"1201": "cooling_operating_mode"` to `BASE_HEATING_CIRCUIT2_PARAMS` in src/bsblan/constants.py
+- [x] 2.2 Add `"cooling_operating_mode": "901"` / `"1201"` to `CircuitConfig.THERMOSTAT_PARAMS` circuits 1 and 2
+- [x] 2.3 Add `Validation.COOLING_OPERATING_MODES` with the device-confirmed value set
+
+## 3. Model
+
+- [x] 3.1 Add optional `cooling_operating_mode` field to `State` in src/bsblan/models.py (type per task 1.2)
+
+## 4. Client Setter
+
+- [x] 4.1 Add `cooling_operating_mode: int | None = None` to `thermostat()` and its internal set helper in src/bsblan/bsblan.py, sending one `/JS` request via `_set_payload` when populated
+- [x] 4.2 Add `_validate_cooling_operating_mode` (mirror `_validate_hvac_mode`) raising `BSBLANInvalidParameterError` for out-of-set values
+- [x] 4.3 Raise `BSBLANInvalidParameterError` when `cooling_operating_mode` is passed on a PPS-bus device (no cooling entry in PPS thermostat params)
+
+## 5. Tests
+
+- [x] 5.1 Extend state fixtures/tests: circuit 1 and circuit 2 reads populate `cooling_operating_mode`; absent/`"---"` param yields `None` without error
+- [x] 5.2 Add setter tests: single `/JS` payload for circuit 1 and 2, multi-parameter call rejected (single-parameter contract), invalid value rejected before any request
+- [x] 5.3 Add PPS rejection test
+- [x] 5.4 Verify basic-config path does not request `901` (existing basic-config test coverage extended if needed)
+
+## 6. Docs & Validation
+
+- [x] 6.1 Update README and docs (getting-started/index/models) feature listing per feature-doc-updates convention
+- [x] 6.2 Run `uv run pytest --cov=src/bsblan --cov-report=term-missing` (total ≥ 95%, patch 100%)
+- [x] 6.3 Run `SKIP=no-commit-to-branch uv run prek run --all-files` until green

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,21 @@
+---
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/cooling-operating-mode/spec.md
+++ b/openspec/specs/cooling-operating-mode/spec.md
@@ -1,0 +1,59 @@
+# cooling-operating-mode
+
+## Purpose
+
+Reading and setting the cooling circuit operating mode (BSB-LAN parameters `901`/`1201`) through the state model and the thermostat setter, scoped to the full API configuration.
+
+## Requirements
+
+### Requirement: State exposes cooling operating mode
+The `State` model SHALL include an optional `cooling_operating_mode` field populated from BSB-LAN parameter `901` (circuit 1) or `1201` (circuit 2) when the full API configuration is active and the device reports the parameter.
+
+#### Scenario: Read cooling operating mode for circuit 1
+- **WHEN** `state()` is called on a full-config device that exposes parameter `901`
+- **THEN** the returned `State.cooling_operating_mode` contains the parameter's name, value, and unit
+
+#### Scenario: Read cooling operating mode for circuit 2
+- **WHEN** `state(circuit=2)` is called on a full-config device that exposes parameter `1201`
+- **THEN** the returned `State.cooling_operating_mode` reflects parameter `1201`
+
+#### Scenario: Device without cooling support
+- **WHEN** `state()` is called on a device where parameter `901` is absent or inactive (`"---"`)
+- **THEN** section validation drops the parameter and `State.cooling_operating_mode` is `None`
+- **AND** no error is raised
+
+#### Scenario: Basic configuration excludes cooling
+- **WHEN** the client resolves the basic (single-circuit) configuration
+- **THEN** parameter `901` is not requested and `State.cooling_operating_mode` is `None`
+
+### Requirement: Thermostat can set cooling operating mode
+The `thermostat()` method SHALL accept an optional `cooling_operating_mode` argument and send it as a single `/JS` request to parameter `901` (circuit 1) or `1201` (circuit 2).
+
+#### Scenario: Set cooling operating mode for circuit 1
+- **WHEN** `thermostat(cooling_operating_mode=1)` is called
+- **THEN** the client sends one `/JS` request with `Parameter` `901`, `Value` `"1"`, and `Type` `"1"`
+
+#### Scenario: Set cooling operating mode for circuit 2
+- **WHEN** `thermostat(cooling_operating_mode=0, circuit=2)` is called
+- **THEN** the client sends one `/JS` request targeting parameter `1201`
+
+#### Scenario: Only one thermostat parameter per call
+- **WHEN** `thermostat(hvac_mode=3, cooling_operating_mode=1)` is called
+- **THEN** `BSBLANError` is raised (existing single-parameter contract)
+- **AND** no HTTP request is sent
+
+### Requirement: Cooling operating mode values are validated
+The client SHALL validate `cooling_operating_mode` against the set of values supported by the device parameter (confirmed from real-device raw data) before sending, and SHALL raise `BSBLANInvalidParameterError` for values outside that set.
+
+#### Scenario: Invalid value rejected
+- **WHEN** `thermostat(cooling_operating_mode=99)` is called
+- **THEN** `BSBLANInvalidParameterError` is raised
+- **AND** no HTTP request is sent
+
+### Requirement: Cooling operating mode is unavailable on PPS bus
+The client SHALL raise `BSBLANInvalidParameterError` when `cooling_operating_mode` is passed to `thermostat()` while the device operates on the PPS bus.
+
+#### Scenario: PPS device rejects cooling operating mode
+- **WHEN** the device uses the PPS bus and `thermostat(cooling_operating_mode=1)` is called
+- **THEN** `BSBLANInvalidParameterError` is raised
+- **AND** no HTTP request is sent

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -833,12 +833,14 @@ class BSBLAN:
         )
         logger.debug("Response for setting time: %s", response)
 
-    async def thermostat(
+    async def thermostat(  # pylint: disable=too-many-arguments
         self,
         target_temperature: str | None = None,
         hvac_mode: int | None = None,
         circuit: int = 1,
         target_temperature_high: str | float | None = None,
+        *,
+        cooling_operating_mode: int | None = None,
     ) -> None:
         """Change the state of the thermostat through BSB-Lan.
 
@@ -850,6 +852,9 @@ class BSBLAN:
                 they are translated to PPS raw values before posting.
             circuit: The heating circuit number (1 or 2). Defaults to 1.
             target_temperature_high: The cooling comfort setpoint to set.
+            cooling_operating_mode: The cooling circuit operating mode to set
+                as raw integer value: 0=Protection, 1=Automatic, 2=Reduced,
+                3=Comfort. Not supported on PPS devices.
 
         Example:
             # Set HC1 temperature
@@ -857,6 +862,9 @@ class BSBLAN:
 
             # Set HC1 cooling comfort setpoint
             await client.thermostat(target_temperature_high="24.0")
+
+            # Set HC1 cooling operating mode
+            await client.thermostat(cooling_operating_mode=1)
 
             # Set HC2 mode
             await client.thermostat(hvac_mode=1, circuit=2)
@@ -871,6 +879,7 @@ class BSBLAN:
             target_temperature,
             hvac_mode,
             target_temperature_high,
+            cooling_operating_mode,
             error_msg=ErrorMsg.MULTI_PARAMETER,
         )
 
@@ -879,15 +888,18 @@ class BSBLAN:
             hvac_mode,
             circuit,
             target_temperature_high,
+            cooling_operating_mode=cooling_operating_mode,
         )
         await self._set_device_state(state)
 
-    async def _prepare_thermostat_state(
+    async def _prepare_thermostat_state(  # pylint: disable=too-many-arguments
         self,
         target_temperature: str | None,
         hvac_mode: int | None,
         circuit: int = 1,
         target_temperature_high: str | float | None = None,
+        *,
+        cooling_operating_mode: int | None = None,
     ) -> dict[str, Any]:
         """Prepare the thermostat state for setting.
 
@@ -896,6 +908,8 @@ class BSBLAN:
             hvac_mode (int | None): The HVAC mode to set as raw integer.
             circuit: The heating circuit number (1 or 2).
             target_temperature_high: The cooling comfort setpoint to set.
+            cooling_operating_mode: The cooling circuit operating mode to set
+                as raw integer.
 
         Returns:
             dict[str, Any]: The prepared state for the thermostat.
@@ -930,6 +944,15 @@ class BSBLAN:
                 hvac_value = Validation.PPS_HVAC_MODE_TO_BSBLAN[hvac_mode]
             state.update(
                 self._set_payload(param_ids["hvac_mode"], hvac_value),
+            )
+        if cooling_operating_mode is not None:
+            param_id = param_ids.get("cooling_operating_mode")
+            if param_id is None:
+                parameter_name = "cooling_operating_mode"
+                raise BSBLANInvalidParameterError(parameter_name)
+            self._validate_cooling_operating_mode(cooling_operating_mode)
+            state.update(
+                self._set_payload(param_id, str(cooling_operating_mode)),
             )
         return state
 
@@ -990,6 +1013,20 @@ class BSBLAN:
         )
         if hvac_mode not in valid_modes:
             raise BSBLANInvalidParameterError(str(hvac_mode))
+
+    def _validate_cooling_operating_mode(self, cooling_operating_mode: int) -> None:
+        """Validate the cooling circuit operating mode.
+
+        Args:
+            cooling_operating_mode (int): The mode to validate. Valid values
+                are 0=Protection, 1=Automatic, 2=Reduced, 3=Comfort.
+
+        Raises:
+            BSBLANInvalidParameterError: If the mode is invalid.
+
+        """
+        if cooling_operating_mode not in Validation.COOLING_OPERATING_MODES:
+            raise BSBLANInvalidParameterError(str(cooling_operating_mode))
 
     def _validate_time_format(self, time_value: str) -> None:
         """Validate the time format.

--- a/src/bsblan/constants.py
+++ b/src/bsblan/constants.py
@@ -40,6 +40,7 @@ BASE_HEATING_PARAMS: Final[dict[str, str]] = {
     "700": "hvac_mode",
     "710": "target_temperature",
     "900": "hvac_mode_changeover",
+    "901": "cooling_operating_mode",
     "902": "target_temperature_high",
     # -------
     "8000": "hvac_action",
@@ -107,6 +108,7 @@ BASE_HEATING_CIRCUIT2_PARAMS: Final[dict[str, str]] = {
     "1000": "hvac_mode",
     "1010": "target_temperature",
     "1200": "hvac_mode_changeover",
+    "1201": "cooling_operating_mode",
     "1202": "target_temperature_high",
     # -------
     "8001": "hvac_action",
@@ -173,11 +175,13 @@ class CircuitConfig:
             "target_temperature": "710",
             "target_temperature_high": "902",
             "hvac_mode": "700",
+            "cooling_operating_mode": "901",
         },
         2: {
             "target_temperature": "1010",
             "target_temperature_high": "1202",
             "hvac_mode": "1000",
+            "cooling_operating_mode": "1201",
         },
     }
     PROBE_PARAMS: Final[dict[int, str]] = {
@@ -240,6 +244,9 @@ class Validation:
     """Validation-related constants for BSBLAN."""
 
     HVAC_MODES: Final[set[int]] = {0, 1, 2, 3}
+    # 901/1201 cooling circuit operating mode (ENUM, verified on device):
+    # 0=Protection, 1=Automatic, 2=Reduced, 3=Comfort
+    COOLING_OPERATING_MODES: Final[set[int]] = {0, 1, 2, 3}
     PPS_HVAC_MODES: Final[set[int]] = {0, 1, 3}
     PPS_HVAC_MODE_TO_BSBLAN: Final[dict[int, str]] = {
         0: "2",  # off

--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -472,6 +472,9 @@ class State(BaseModel):
     target_temperature_high: EntityInfo[float] | None = None
     hvac_action: EntityInfo[int] | None = None
     hvac_mode_changeover: EntityInfo[int] | None = None
+    # 901/1201: cooling circuit operating mode
+    # (0=Protection, 1=Automatic, 2=Reduced, 3=Comfort)
+    cooling_operating_mode: EntityInfo[int] | None = None
     current_temperature: EntityInfo[float] | None = None
     room1_temp_setpoint_boost: EntityInfo[float] | None = None
 

--- a/tests/fixtures/state.json
+++ b/tests/fixtures/state.json
@@ -36,6 +36,18 @@
     "readwrite": 0,
     "unit": ""
   },
+  "901": {
+    "name": "Operating mode",
+    "dataType_name": "ENUM",
+    "dataType_family": "ENUM",
+    "error": 0,
+    "value": "3",
+    "desc": "Comfort",
+    "dataType": 1,
+    "readonly": 0,
+    "readwrite": 0,
+    "unit": ""
+  },
   "902": {
     "name": "Cooling circuit 1 - Comfort setpoint",
     "dataType_name": "TEMP",

--- a/tests/fixtures/state_circuit2.json
+++ b/tests/fixtures/state_circuit2.json
@@ -36,6 +36,18 @@
     "readwrite": 0,
     "unit": ""
   },
+  "1201": {
+    "name": "Operating mode",
+    "dataType_name": "ENUM",
+    "dataType_family": "ENUM",
+    "error": 0,
+    "value": "0",
+    "desc": "Protection",
+    "dataType": 1,
+    "readonly": 0,
+    "readwrite": 0,
+    "unit": ""
+  },
   "1202": {
     "name": "Cooling circuit 2 - Comfort setpoint",
     "dataType_name": "TEMP",

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -151,6 +151,9 @@ async def test_state_circuit2(monkeypatch: Any) -> None:
         assert state.current_temperature.value == 18.5
         assert state.target_temperature_high is not None
         assert state.target_temperature_high.value == 24.0
+        assert state.cooling_operating_mode is not None
+        assert state.cooling_operating_mode.value == 0
+        assert state.cooling_operating_mode.desc == "Protection"
 
 
 @pytest.mark.asyncio
@@ -457,6 +460,35 @@ async def test_thermostat_circuit2_invalid_cooling_temperature(
             target_temperature_high="17",
             circuit=2,
         )
+
+
+@pytest.mark.asyncio
+async def test_thermostat_circuit2_cooling_operating_mode(
+    mock_bsblan_circuit: BSBLAN,
+    aresponses: ResponsesMockServer,
+) -> None:
+    """Test setting the cooling operating mode on circuit 2."""
+    mock_bsblan_circuit._temperature._circuit_temp_ranges[2] = {
+        "min": 16.0,
+        "max": 28.0,
+    }
+    mock_bsblan_circuit._temperature._circuit_temp_initialized.add(2)
+
+    expected_data = {
+        "Parameter": "1201",
+        "Value": "0",
+        "Type": "1",
+    }
+    aresponses.add(
+        "example.com",
+        "/JS",
+        "POST",
+        create_response_handler(expected_data),
+    )
+    await mock_bsblan_circuit.thermostat(
+        cooling_operating_mode=0,
+        circuit=2,
+    )
 
 
 # --- Temperature range initialization tests ---

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -24,6 +24,7 @@ def test_build_api_config_defaults_to_full() -> None:
         "700",
         "710",
         "770",
+        "901",
         "902",
         "712",
         "714",
@@ -69,7 +70,7 @@ def test_build_api_config_basic_is_single_circuit() -> None:
         "716": "comfort_setpoint_max",
     }
     # Cooling and boost params are excluded.
-    for excluded in ("900", "902", "770", "905", "903", "712"):
+    for excluded in ("900", "901", "902", "770", "905", "903", "712"):
         assert excluded not in config["heating"]
         assert excluded not in config["staticValues"]
     # Only a single circuit is supported.

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -297,6 +297,22 @@ async def test_pps_thermostat_rejects_cooling_temperature(
 
 
 @pytest.mark.asyncio
+async def test_pps_thermostat_rejects_cooling_operating_mode(
+    pps_bsblan: BSBLAN,
+) -> None:
+    """Test PPS climate rejects cooling operating mode writes."""
+    pps_bsblan._temperature._circuit_temp_ranges[1] = {"min": 8.0, "max": 30.0}
+    pps_bsblan._temperature._circuit_temp_initialized.add(1)
+    request_mock = AsyncMock(return_value={"status": "ok"})
+    pps_bsblan._request = request_mock  # type: ignore[method-assign]
+
+    with pytest.raises(BSBLANInvalidParameterError, match="cooling_operating_mode"):
+        await pps_bsblan.thermostat(cooling_operating_mode=1)
+
+    request_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_pps_thermostat_rejects_unsupported_eco_mode(
     pps_bsblan: BSBLAN,
 ) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -70,6 +70,11 @@ async def test_state(monkeypatch: Any) -> None:
     assert state.hvac_mode_changeover.value == 2
     assert state.hvac_mode_changeover.desc == "Reduced"
 
+    # Cooling operating mode assertions
+    assert state.cooling_operating_mode is not None
+    assert state.cooling_operating_mode.value == 3
+    assert state.cooling_operating_mode.desc == "Comfort"
+
     # HVAC action assertions
     assert state.hvac_action is not None
     assert state.hvac_action.value == 122
@@ -87,7 +92,7 @@ async def test_state(monkeypatch: Any) -> None:
 
     # Verify API call
     request_mock.assert_awaited_once_with(
-        params={"Parameter": "700,710,900,902,8000,8740,770"}
+        params={"Parameter": "700,710,900,901,902,8000,8740,770"}
     )
 
 
@@ -156,3 +161,40 @@ async def test_state_without_cooling_strips_target_temperature_high(
         assert [
             call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
         ] == ["700,902", "700"]
+
+
+@pytest.mark.asyncio
+async def test_state_without_cooling_strips_cooling_operating_mode(
+    monkeypatch: Any,
+) -> None:
+    """Test unsupported cooling operating mode is stripped during validation."""
+    async with aiohttp.ClientSession() as session:
+        config = BSBLANConfig(host="example.com")
+        bsblan = BSBLAN(config, session=session)
+
+        monkeypatch.setattr(bsblan, "_firmware_version", "1.0.38-20200730234859")
+        monkeypatch.setattr(bsblan, "_supports_full_config", True)
+        bsblan._api_data = {
+            section: params.copy() for section, params in API_FULL.items()
+        }
+        bsblan._validator._api_validator = APIValidator(bsblan._api_data)
+
+        state_data = json.loads(load_fixture("state.json"))
+        validation_response = {"700": state_data["700"]}
+        fetch_response = {"700": state_data["700"]}
+        request_mock: AsyncMock = AsyncMock(
+            side_effect=[validation_response, fetch_response]
+        )
+        monkeypatch.setattr(bsblan, "_request", request_mock)
+
+        state: State = await bsblan.state(
+            include=["hvac_mode", "cooling_operating_mode"]
+        )
+
+        assert state.hvac_mode is not None
+        assert state.cooling_operating_mode is None
+        assert bsblan._api_data is not None
+        assert "901" not in bsblan._api_data["heating"]
+        assert [
+            call.kwargs["params"]["Parameter"] for call in request_mock.await_args_list
+        ] == ["700,901", "700"]

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -231,3 +231,39 @@ async def test_cooling_temperature_with_other_parameter_raises(
             target_temperature_high="24",
         )
     assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER
+
+
+@pytest.mark.asyncio
+async def test_set_cooling_operating_mode(
+    mock_bsblan: BSBLAN,
+    aresponses: ResponsesMockServer,
+) -> None:
+    """Test setting the cooling operating mode on circuit 1."""
+    expected_data = {"Parameter": "901", "Value": "1", "Type": "1"}
+    aresponses.add(
+        "example.com",
+        "/JS",
+        "POST",
+        create_response_handler(expected_data),
+    )
+    await mock_bsblan.thermostat(cooling_operating_mode=1)
+
+
+@pytest.mark.asyncio
+async def test_invalid_cooling_operating_mode(mock_bsblan: BSBLAN) -> None:
+    """Test that an invalid cooling operating mode is rejected."""
+    with pytest.raises(BSBLANInvalidParameterError):
+        await mock_bsblan.thermostat(cooling_operating_mode=99)
+
+
+@pytest.mark.asyncio
+async def test_cooling_operating_mode_with_other_parameter_raises(
+    mock_bsblan: BSBLAN,
+) -> None:
+    """Test cooling operating mode respects one-parameter-per-call rule."""
+    with pytest.raises(BSBLANError) as exc_info:
+        await mock_bsblan.thermostat(
+            hvac_mode=3,
+            cooling_operating_mode=1,
+        )
+    assert str(exc_info.value) == ErrorMsg.MULTI_PARAMETER


### PR DESCRIPTION
Add support to set cooling mode on circuit 1 and 2. (901 and ...)

Also this pull request introduces three new prompt files for OpenSpec experimental workflows and refines the validation logic in the `.github/hooks/run_validation_after_edits.sh` script. The main improvements include more robust and targeted validation after file edits, as well as comprehensive, well-documented prompt guides for applying, archiving, and exploring OpenSpec changes.

**Validation logic improvements:**

- **Targeted validation trigger:** The validation script now only triggers the Python validation suite if an edit tool is used and code/config files are actually modified, rather than running for any edit action. This reduces unnecessary validation runs and improves performance. [[1]](diffhunk://#diff-aabf264d1186014ef7bd010f0fcdcd6abc12c57a150df974816391e5fe9a3dcdL9-R27) [[2]](diffhunk://#diff-aabf264d1186014ef7bd010f0fcdcd6abc12c57a150df974816391e5fe9a3dcdL46-R70)
- **Environment variable for prek:** The script now sets `SKIP=no-commit-to-branch` when running `prek` to ensure proper pre-commit hook behavior.

**New OpenSpec workflow prompts:**

- **Apply prompt:** Adds `.github/prompts/opsx-apply.prompt.md`, a detailed step-by-step guide for implementing tasks from an OpenSpec change, including change selection, status checking, task implementation, and guardrails for safe, minimal, and clear task completion.
- **Archive prompt:** Adds `.github/prompts/opsx-archive.prompt.md`, which provides a robust workflow for archiving completed changes, including checks for incomplete artifacts or tasks, delta spec sync, and clear user prompts and summaries.
- **Explore prompt:** Adds `.github/prompts/opsx-explore.prompt.md`, defining an "explore mode" for open-ended investigation, brainstorming, and requirements clarification, with strong guardrails to prevent accidental implementation and encourage visual thinking.