### PR TITLE
Add OpenSpec skills and cooling operating mode support

### DIFF
--- a/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/.openspec.yaml
@@ -1,0 +1,3 @@
+---
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/design.md
+++ b/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/design.md
@@ -1,0 +1,161 @@
+# Design: improve-client-readability-domain-slices
+
+## Context
+
+`src/bsblan/bsblan.py` is currently ~1592 lines. Previous behavior-preserving
+stages already extracted:
+
+- HTTP transport → `src/bsblan/_transport.py` (`BSBLANTransport`)
+- version/capability resolution → `src/bsblan/_version.py` (`VersionResolver`)
+- lazy API validation → `src/bsblan/_validation.py` (`SectionValidator`)
+- temperature range/unit handling → `src/bsblan/_temperature.py`
+  (`TemperatureManager`)
+
+The remaining `BSBLAN` facade still mixes four large domain concerns:
+
+1. Hot water: `hot_water_state`, `hot_water_config`, `hot_water_schedule`,
+   `set_hot_water`, `_fetch_hot_water_data`, `_prepare_hot_water_state`
+   (~L1074–1441).
+2. Schedules: `heating_schedule`, `set_heating_schedule`,
+   `set_hot_water_schedule` (~L1233–1402, overlapping hot water).
+3. Low-level parameter reads: `read_parameters`, `get_parameter_id`,
+   `get_parameter_ids`, `read_parameters_by_name` (~L1442–end).
+4. Thermostat write preparation: `thermostat`, `_prepare_thermostat_state`,
+   `_thermostat_params`, HVAC/cooling-mode validation (~L836–1030).
+
+Constraints:
+
+- Behavior-preserving: no public API, exception, model, or constant changes.
+- The `mock_bsblan` fixture and many tests monkeypatch `bsblan._request` (and
+  other private attributes) **after** construction, so collaborators must read
+  facade state via live lambdas, not captured bound methods (proven pattern
+  from the `SectionValidator` / `TemperatureManager` extractions).
+- Coverage gate: ≥95% total, 100% patch coverage.
+- A PostToolUse hook runs full validation after Python edits; multi-file edits
+  should be batched atomically so the Ruff autofix hook never sees a broken
+  intermediate state (it strips transiently-unused imports).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add the two missing retry characterization tests (401/403 → single request,
+  `BSBLANAuthError`, no retry) *before* refactoring.
+- Extract hot water, schedule, and parameter-read logic into focused internal
+  modules; keep `BSBLAN` as a thin public facade.
+- Make `bsblan.py` visibly smaller and easier to scan.
+- Keep every existing test green with edits limited to moved private
+  implementation locations.
+
+**Non-Goals:**
+
+- Renaming `get_temperature_unit` or adding user-facing APIs.
+- Changing parameter IDs, cooling behavior, or retry/transport/version/
+  validation/temperature behavior.
+- Reorganizing `constants.py` or `models.py`.
+- User-facing documentation changes.
+
+## Decisions
+
+### D1: Retry tests first, in `tests/test_backoff_retry.py`
+
+Add `test_no_retry_on_401_auth_error` and `test_no_retry_on_403_auth_error`
+before any extraction. Each registers exactly one mocked response and asserts
+`BSBLANAuthError`. Registering a single response inherently proves no retry
+occurred (a retry would find no registered response and fail differently).
+This pins the auth/no-retry contract so the refactor cannot silently regress
+it. No transport code changes.
+
+### D2: Collaborator classes with live-lambda wiring (same pattern as Stages 4–5)
+
+Each extracted module holds a small class constructed in
+`BSBLAN.__post_init__` with keyword-only callbacks:
+
+- `src/bsblan/_hot_water.py` — `HotWaterManager`: owns
+  `_fetch_hot_water_data`, `_prepare_hot_water_state`, and the bodies of
+  `hot_water_state`, `hot_water_config`, `hot_water_schedule`,
+  `set_hot_water`.
+- `src/bsblan/_schedules.py` — `ScheduleManager`: owns the bodies of
+  `heating_schedule`, `set_heating_schedule`, `set_hot_water_schedule`, and
+  the shared schedule parse/serialize logic. Note: `heating_schedule`
+  intentionally keeps its own by-key mapping (tolerates missing params) and is
+  NOT routed through `_request_named_params`.
+- `src/bsblan/_parameters.py` — `ParameterReader`: owns the bodies of
+  `read_parameters`, `get_parameter_id`, `get_parameter_ids`,
+  `read_parameters_by_name`.
+
+Callbacks that tests monkeypatch on the facade (`_request`, `_set_payload`
+usage sites, `static_values`, etc.) are passed as live lambdas
+(`lambda **kw: self._request(**kw)  # noqa: PLW0108`); stable helpers may be
+passed as bound methods only if verified un-monkeypatched (grep both attribute
+and string forms, e.g. `"_prepare_hot_water_state"`).
+
+Alternative considered: plain module-level functions taking the client as
+first argument. Rejected: collaborator classes match the established
+`_transport`/`_validation`/`_temperature` pattern and keep the callback
+surface explicit and testable.
+
+### D3: Facade keeps thin delegations with unchanged signatures/docstrings
+
+Every public method (`hot_water_state`, `set_hot_water`, `heating_schedule`,
+`read_parameters`, …) stays on `BSBLAN` and delegates in one or two lines.
+Private helpers that tests call directly (check via grep before deleting —
+e.g. `_prepare_hot_water_state`, `_fetch_hot_water_data`) either keep a thin
+delegation on the facade or the tests are redirected to the collaborator,
+whichever is the smaller diff. State that is shared across domains
+(`_api_data`, `_available_circuits`) stays on the facade.
+
+### D4: Thermostat extraction is conditional (evaluate last)
+
+`_prepare_thermostat_state` depends on `TemperatureManager` validation,
+`_validate_hvac_mode`, `_validate_cooling_operating_mode`, PPS guards, and
+`_thermostat_params`. Extract to `src/bsblan/_thermostat.py` only if the
+result removes more complexity from `bsblan.py` than the callback wiring adds
+(rough test: net line reduction in `bsblan.py` and ≤6 constructor callbacks).
+Otherwise leave it on the facade and record the decision in tasks.
+
+### D5: One extraction per commit, atomic multi-file edits
+
+Each module extraction lands as its own commit with tests green, mirroring the
+earlier stage-per-PR discipline. Edits that add imports plus their consumers
+are applied in one batch so the Ruff autofix hook cannot strip
+transiently-unused imports.
+
+## Risks / Trade-offs
+
+- [Tests monkeypatch moved privates by string name, missed by attribute grep]
+  → Grep both `\._name` and `"_name"` string forms across `tests/` before
+  moving each method (this bit Stage 4 twice).
+- [Ruff autofix strips imports between edit batches] → Batch each extraction
+  atomically; put annotation-only imports in `TYPE_CHECKING` blocks in the
+  same edit that introduces their first usage.
+- [Callback wiring grows facade `__post_init__`] → Acceptable: `__post_init__`
+  becomes the single explicit wiring map; each collaborator gets only the
+  callbacks it needs.
+- [Coverage drops if delegations are untested] → Delegations are one-liners
+  exercised by existing public-behavior tests; run
+  `uv run pytest --cov=src/bsblan --cov-report=term-missing` after each
+  extraction.
+- [Thermostat extraction makes wiring awkward] → D4 makes it explicitly
+  optional; skipping it is an acceptable outcome.
+
+## Migration Plan
+
+Internal-only refactor; no deployment or user migration. Rollback = revert the
+extraction commit(s). Suggested order (each step independently green):
+
+1. Retry characterization tests.
+2. `_parameters.py` (smallest, fewest callbacks).
+3. `_hot_water.py`.
+4. `_schedules.py` (depends on hot-water fetch helpers staying reachable).
+5. Optional `_thermostat.py` evaluation.
+
+## Open Questions
+
+- Whether `_thermostat.py` clears the D4 bar — decided during implementation,
+  not blocking.
+- Whether `set_hot_water_schedule` lives in `_hot_water.py` or
+  `_schedules.py`: default is `_schedules.py` (shared schedule
+  serialization), but if it shares more code with `set_hot_water` payload
+  preparation, keep schedule serialization helpers in `_schedules.py` and let
+  `HotWaterManager` call them.

--- a/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/proposal.md
+++ b/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: improve-client-readability-domain-slices
+
+## Why
+
+`src/bsblan/bsblan.py` is still ~1592 lines after the transport, version,
+validation, and temperature extractions, and it mixes several remaining domain
+concerns (hot water, schedules, low-level parameter reads, thermostat write
+preparation). This makes the facade hard to scan and review, and the retry
+policy still lacks characterization tests proving `401`/`403` responses are not
+retried.
+
+## What Changes
+
+- Add missing retry characterization tests (`test_no_retry_on_401_auth_error`,
+  `test_no_retry_on_403_auth_error`) before any refactoring, each registering a
+  single mocked response and asserting `BSBLANAuthError`.
+- Extract cohesive internal domain modules while keeping `BSBLAN` as the public
+  facade with thin delegations:
+  - `src/bsblan/_hot_water.py`: hot water getters/setters and hot water state
+    preparation.
+  - `src/bsblan/_schedules.py`: `heating_schedule`, `set_heating_schedule`, and
+    `set_hot_water_schedule` shared schedule logic.
+  - `src/bsblan/_parameters.py`: `read_parameters`, `get_parameter_id`,
+    `get_parameter_ids`, and `read_parameters_by_name`.
+  - Optionally `src/bsblan/_thermostat.py` for thermostat write preparation,
+    only if it meaningfully reduces `BSBLAN` complexity without awkward
+    callback wiring.
+- Reuse existing helpers (`BSBLAN._request`, `_set_payload`,
+  `_set_device_state`, `_apply_include_filter`, `_request_named_params`,
+  `SectionValidator`, `TemperatureManager`) rather than duplicating logic.
+- Update tests only where private implementation locations move.
+
+No public `BSBLAN` method names, signatures, return types, exceptions,
+constants, models, or documented user workflows change.
+
+## Capabilities
+
+### New Capabilities
+
+- `client-retry-policy`: Characterizes the existing retry behavior for
+  authentication failures — HTTP `401` and `403` responses raise
+  `BSBLANAuthError` after a single request with no retries.
+
+### Modified Capabilities
+
+<!-- None. This is a behavior-preserving internal refactor; no existing
+spec-level requirements change. -->
+
+## Impact
+
+- **Code**: `src/bsblan/bsblan.py` shrinks significantly; new internal modules
+  `_hot_water.py`, `_schedules.py`, `_parameters.py` (and optionally
+  `_thermostat.py`) are added. `constants.py` and `models.py` stay untouched
+  unless strictly required by the extraction.
+- **Tests**: `tests/test_backoff_retry.py` gains two tests; existing tests are
+  updated only where they reference moved private implementation details.
+  Coverage must stay ≥ 95% total with 100% patch coverage.
+- **Docs**: No user-facing documentation changes expected (internal layout
+  only).
+- **Out of scope**: renaming `get_temperature_unit`, new user-facing APIs,
+  parameter ID or cooling behavior changes, reorganizing `constants.py` /
+  `models.py`, and any transport/retry/version/validation/temperature behavior
+  changes beyond the two missing retry tests.

--- a/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/specs/client-retry-policy/spec.md
+++ b/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/specs/client-retry-policy/spec.md
@@ -1,0 +1,21 @@
+# Delta Spec: client-retry-policy
+
+## ADDED Requirements
+
+### Requirement: Authentication failures are not retried
+
+The client SHALL treat HTTP `401` and `403` responses as non-retryable
+authentication failures: exactly one HTTP request is made and a
+`BSBLANAuthError` is raised, without invoking the backoff retry policy.
+
+#### Scenario: 401 response raises auth error after a single request
+
+- **WHEN** the BSB-LAN device responds to a request with HTTP `401` and only
+  one mocked response is registered
+- **THEN** the client raises `BSBLANAuthError` and no retry request is made
+
+#### Scenario: 403 response raises auth error after a single request
+
+- **WHEN** the BSB-LAN device responds to a request with HTTP `403` and only
+  one mocked response is registered
+- **THEN** the client raises `BSBLANAuthError` and no retry request is made

--- a/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/tasks.md
+++ b/openspec/changes/archive/2026-07-04-improve-client-readability-domain-slices/tasks.md
@@ -1,0 +1,91 @@
+# Tasks: improve-client-readability-domain-slices
+
+## 1. Retry Characterization Tests
+
+- [x] 1.1 Add `test_no_retry_on_401_auth_error` to `tests/test_backoff_retry.py`
+      registering exactly one mocked `401` response and asserting
+      `BSBLANAuthError`
+- [x] 1.2 Add `test_no_retry_on_403_auth_error` with one mocked `403` response
+      asserting `BSBLANAuthError`
+- [x] 1.3 Run `uv run pytest --no-cov tests/test_backoff_retry.py` and confirm
+      green
+
+## 2. Extract Parameter Reads (`_parameters.py`)
+
+- [x] 2.1 Grep `tests/` for attribute AND string-form references to
+      `read_parameters`, `get_parameter_id`, `get_parameter_ids`,
+      `read_parameters_by_name` and any private helpers they use
+- [x] 2.2 Create `src/bsblan/_parameters.py` with a `ParameterReader` class
+      owning the method bodies; wire monkeypatched callbacks (`_request`, …)
+      as live lambdas in `BSBLAN.__post_init__`
+- [x] 2.3 Reduce the four `BSBLAN` methods to thin delegations with unchanged
+      signatures, docstrings, return types, and exceptions
+- [x] 2.4 Redirect any tests that reference moved privates; run full
+      `uv run pytest --cov=src/bsblan --cov-report=term-missing` and confirm
+      coverage gate
+
+## 3. Extract Hot Water (`_hot_water.py`)
+
+- [x] 3.1 Grep `tests/` for references to `_fetch_hot_water_data`,
+      `_prepare_hot_water_state`, `hot_water_*`, `set_hot_water` privates
+      (attribute and string forms)
+- [x] 3.2 Create `src/bsblan/_hot_water.py` with `HotWaterManager` owning
+      `_fetch_hot_water_data`, `_prepare_hot_water_state`, and the bodies of
+      `hot_water_state`, `hot_water_config`, `hot_water_schedule`,
+      `set_hot_water`; reuse `SectionValidator` hot-water cache/group APIs and
+      facade helpers (`_apply_include_filter`, `_set_payload`,
+      `_set_device_state`) via callbacks
+- [x] 3.3 Keep `BSBLAN` hot-water methods as thin delegations; keep
+      `set_hot_water_cache` public delegation unchanged
+- [x] 3.4 Redirect moved-private test references; run full coverage suite and
+      confirm green
+
+## 4. Extract Schedules (`_schedules.py`)
+
+- [x] 4.1 Grep `tests/` for references to `heating_schedule`,
+      `set_heating_schedule`, `set_hot_water_schedule` internals
+- [x] 4.2 Create `src/bsblan/_schedules.py` with `ScheduleManager` owning
+      shared schedule parse/serialize logic plus the bodies of
+      `heating_schedule`, `set_heating_schedule`, `set_hot_water_schedule`;
+      preserve `heating_schedule`'s tolerant by-key mapping (do NOT route
+      through `_request_named_params`)
+- [x] 4.3 Keep facade methods as thin delegations; decide `_hot_water.py` vs
+      `_schedules.py` placement for DHW schedule serialization per design D5
+      open question and record the choice here
+      → Decision: DHW schedule writes live in `_schedules.py`
+      (`ScheduleManager._write_day_schedules` is shared by heating and DHW);
+      `set_hot_water` payload prep stays in `_hot_water.py` (no overlap).
+- [x] 4.4 Redirect moved-private test references; run full coverage suite and
+      confirm green (459 passed, 100% coverage; no test edits needed)
+
+## 5. Evaluate Optional Thermostat Extraction (`_thermostat.py`)
+
+- [x] 5.1 Assess per design D4: extract `_prepare_thermostat_state`,
+      `_thermostat_params`, and HVAC/cooling-mode validation only if it nets a
+      line reduction in `bsblan.py` with ≤6 constructor callbacks
+      → Extracted: `ThermostatWriter` needs only 3 callbacks
+      (`uses_pps_bus`, `temperature`, `set_payload`) and removes ~120 lines.
+- [x] 5.2 If extracting: create `src/bsblan/_thermostat.py`, keep
+      `thermostat()` as facade delegation, redirect tests, run coverage suite.
+      If skipping: record the rationale in this file and mark done
+      → Done. `thermostat()` stays public on the facade;
+      `_validate_target_temperature[_high]` delegations kept (test-referenced);
+      no test edits needed. 459 passed, 100% coverage.
+
+## 6. Final Validation
+
+- [x] 6.1 Verify no public API changes: `BSBLAN` method names, signatures,
+      return types, and exceptions unchanged; no edits to `constants.py` /
+      `models.py` unless strictly required (document any)
+      → Verified: refactor diff touches only new `_*.py` modules, `bsblan.py`
+      (1592 → 1295 lines), and `tests/test_backoff_retry.py`.
+- [x] 6.2 Confirm no user-facing docs changes are needed (README, docs/)
+      → No internal references in docs; no behavior changes.
+- [x] 6.3 Run `uv run pytest --no-cov tests/test_backoff_retry.py`
+      → 12 passed.
+- [x] 6.4 Run `uv run pytest --cov=src/bsblan --cov-report=term-missing`;
+      confirm total ≥95% and 100% patch coverage on modified lines
+      → 459 passed, 100.00% total coverage (0 missing lines).
+- [x] 6.5 Run `SKIP=no-commit-to-branch uv run prek run --all-files` and
+      resolve any formatter/lint churn (expect one autofix pass)
+      → All hooks green.

--- a/openspec/specs/client-retry-policy/spec.md
+++ b/openspec/specs/client-retry-policy/spec.md
@@ -1,0 +1,27 @@
+# client-retry-policy
+
+## Purpose
+
+Retry behavior of the BSB-LAN HTTP client: which failures are retried with
+exponential backoff and which fail immediately, so callers can rely on
+predictable error handling and request counts.
+
+## Requirements
+
+### Requirement: Authentication failures are not retried
+
+The client SHALL treat HTTP `401` and `403` responses as non-retryable
+authentication failures: exactly one HTTP request is made and a
+`BSBLANAuthError` is raised, without invoking the backoff retry policy.
+
+#### Scenario: 401 response raises auth error after a single request
+
+- **WHEN** the BSB-LAN device responds to a request with HTTP `401` and only
+  one mocked response is registered
+- **THEN** the client raises `BSBLANAuthError` and no retry request is made
+
+#### Scenario: 403 response raises auth error after a single request
+
+- **WHEN** the BSB-LAN device responds to a request with HTTP `403` and only
+  one mocked response is registered
+- **THEN** the client raises `BSBLANAuthError` and no retry request is made

--- a/src/bsblan/_hot_water.py
+++ b/src/bsblan/_hot_water.py
@@ -1,0 +1,252 @@
+"""Hot water domain logic for BSB-LAN."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from .constants import ErrorMsg, HotWaterParams
+from .exceptions import BSBLANError
+from .models import (
+    HotWaterConfig,
+    HotWaterSchedule,
+    HotWaterState,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from .models import SetHotWaterParam
+
+# TypeVar for hot water data models
+HotWaterDataT = TypeVar(
+    "HotWaterDataT", HotWaterState, HotWaterConfig, HotWaterSchedule
+)
+
+logger = logging.getLogger(__name__)
+
+
+class HotWaterManager:
+    """Read and write hot water state, configuration, and schedules."""
+
+    def __init__(  # noqa: PLR0913  # pylint: disable=too-many-arguments
+        self,
+        *,
+        ensure_group_validated: Callable[
+            [str, set[str], list[str] | None], Awaitable[None]
+        ],
+        get_param_cache: Callable[[], dict[str, str]],
+        apply_include_filter: Callable[
+            [dict[str, str], list[str] | None], dict[str, str]
+        ],
+        request_named_params: Callable[[dict[str, str]], Awaitable[dict[str, Any]]],
+        validate_single_parameter: Callable[..., None],
+        set_payload: Callable[[str, str], dict[str, Any]],
+        set_device_state: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        """Initialize the hot water manager.
+
+        Args:
+            ensure_group_validated: Validates a hot water param group lazily.
+            get_param_cache: Returns the validated hot water param cache.
+            apply_include_filter: Filters params by requested names.
+            request_named_params: Requests params and maps them to names.
+            validate_single_parameter: Ensures only one parameter is set.
+            set_payload: Builds a set-parameter payload.
+            set_device_state: Sends a set-parameter request to the device.
+
+        """
+        self._ensure_group_validated = ensure_group_validated
+        self._get_param_cache = get_param_cache
+        self._apply_include_filter = apply_include_filter
+        self._request_named_params = request_named_params
+        self._validate_single_parameter = validate_single_parameter
+        self._set_payload = set_payload
+        self._set_device_state = set_device_state
+
+    async def fetch_data(
+        self,
+        param_filter: set[str],
+        model_class: type[HotWaterDataT],
+        error_msg: str,
+        group_name: str,
+        include: list[str] | None = None,
+    ) -> HotWaterDataT:
+        """Fetch hot water data for a specific parameter set.
+
+        This is a generic helper method that fetches hot water parameters
+        based on the provided filter and returns the appropriate model.
+        It uses granular lazy loading to validate only the specific param group.
+
+        Args:
+            param_filter: Set of parameter IDs to fetch.
+            model_class: The dataclass type to deserialize the response into.
+            error_msg: Error message if no parameters are available.
+            group_name: Name of the param group for lazy validation tracking.
+            include: Optional list of parameter names to fetch. If None,
+                fetches all parameters in the group.
+
+        Returns:
+            The populated model instance.
+
+        Raises:
+            BSBLANError: If no parameters are available for the filter.
+
+        """
+        # Granular lazy load: validate only this param group on first access
+        # Pass include filter so we only validate requested params
+        await self._ensure_group_validated(group_name, param_filter, include)
+
+        # Use cached validated params
+        filtered_params = {
+            param_id: param_name
+            for param_id, param_name in self._get_param_cache().items()
+            if param_id in param_filter
+        }
+
+        # Apply include filter if specified
+        filtered_params = self._apply_include_filter(filtered_params, include)
+
+        if not filtered_params:
+            raise BSBLANError(error_msg)
+
+        data = await self._request_named_params(filtered_params)
+        return model_class.model_validate(data)
+
+    async def state(self, include: list[str] | None = None) -> HotWaterState:
+        """Get essential hot water state for frequent polling.
+
+        Args:
+            include: Optional list of parameter names to fetch.
+
+        Returns:
+            HotWaterState: Essential hot water state information.
+
+        """
+        return await self.fetch_data(
+            param_filter=HotWaterParams.ESSENTIAL,
+            model_class=HotWaterState,
+            error_msg="No essential hot water parameters available",
+            group_name="essential",
+            include=include,
+        )
+
+    async def config(self, include: list[str] | None = None) -> HotWaterConfig:
+        """Get hot water configuration and advanced settings.
+
+        Args:
+            include: Optional list of parameter names to fetch.
+
+        Returns:
+            HotWaterConfig: Hot water configuration information.
+
+        """
+        return await self.fetch_data(
+            param_filter=HotWaterParams.CONFIG,
+            model_class=HotWaterConfig,
+            error_msg="No hot water configuration parameters available",
+            group_name="config",
+            include=include,
+        )
+
+    async def schedule(self, include: list[str] | None = None) -> HotWaterSchedule:
+        """Get hot water time program schedules.
+
+        Args:
+            include: Optional list of parameter names to fetch.
+
+        Returns:
+            HotWaterSchedule: Hot water schedule information.
+
+        """
+        return await self.fetch_data(
+            param_filter=HotWaterParams.SCHEDULE,
+            model_class=HotWaterSchedule,
+            error_msg="No hot water schedule parameters available",
+            group_name="schedule",
+            include=include,
+        )
+
+    async def set_hot_water(self, params: SetHotWaterParam) -> None:
+        """Change the state of the hot water system through BSB-Lan.
+
+        Only one parameter should be set at a time (BSB-LAN API limitation).
+
+        Args:
+            params: SetHotWaterParam object containing the parameter to set.
+
+        Raises:
+            BSBLANError: If multiple parameters are set or no parameter is set.
+
+        """
+        # Validate only one parameter is being set
+        time_program_params: list[str] = []
+        if params.dhw_time_programs:
+            programs = params.dhw_time_programs
+            time_program_params.extend(
+                prog
+                for prog in [
+                    programs.monday,
+                    programs.tuesday,
+                    programs.wednesday,
+                    programs.thursday,
+                    programs.friday,
+                    programs.saturday,
+                    programs.sunday,
+                    programs.standard_values,
+                ]
+                if prog
+            )
+
+        self._validate_single_parameter(
+            params.nominal_setpoint,
+            params.reduced_setpoint,
+            params.nominal_setpoint_max,
+            params.operating_mode,
+            params.eco_mode_selection,
+            params.dhw_charging_priority,
+            params.legionella_function_setpoint,
+            params.legionella_function_periodicity,
+            params.legionella_function_day,
+            params.legionella_function_time,
+            params.legionella_function_dwelling_time,
+            params.operating_mode_changeover,
+            *time_program_params,
+            error_msg=ErrorMsg.MULTI_PARAMETER,
+        )
+
+        state = self.prepare_state(params)
+        await self._set_device_state(state)
+
+    def prepare_state(self, params: SetHotWaterParam) -> dict[str, Any]:
+        """Prepare the hot water state for setting.
+
+        Args:
+            params: SetHotWaterParam object containing the parameter to set.
+
+        Returns:
+            dict[str, Any]: The prepared state for the hot water.
+
+        Raises:
+            BSBLANError: If no state is provided.
+
+        """
+        state: dict[str, Any] = {}
+
+        # Process all mapped parameters using constants
+        for param_id, attr_name in HotWaterParams.SETTABLE.items():
+            value = getattr(params, attr_name)
+            if value is not None:
+                state.update(self._set_payload(param_id, str(value)))
+
+        # Process time programs if provided using constants
+        if params.dhw_time_programs:
+            for param_id, attr_name in HotWaterParams.TIME_PROGRAMS.items():
+                value = getattr(params.dhw_time_programs, attr_name)
+                if value is not None:
+                    state.update(self._set_payload(param_id, value))
+
+        if not state:
+            raise BSBLANError(ErrorMsg.NO_STATE)
+
+        return state

--- a/src/bsblan/_hot_water.py
+++ b/src/bsblan/_hot_water.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from .constants import ErrorMsg, HotWaterParams
@@ -22,8 +21,6 @@ if TYPE_CHECKING:
 HotWaterDataT = TypeVar(
     "HotWaterDataT", HotWaterState, HotWaterConfig, HotWaterSchedule
 )
-
-logger = logging.getLogger(__name__)
 
 
 class HotWaterManager:

--- a/src/bsblan/_parameters.py
+++ b/src/bsblan/_parameters.py
@@ -1,0 +1,155 @@
+"""Low-level parameter lookup and read helpers for BSB-LAN."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from .constants import ErrorMsg
+from .exceptions import BSBLANError
+from .models import EntityInfo
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from .constants import APIConfig
+
+
+class ParameterReader:
+    """Resolve and read BSB-LAN parameters by ID or name."""
+
+    def __init__(
+        self,
+        *,
+        request: Callable[..., Awaitable[dict[str, Any]]],
+        get_api_data: Callable[[], APIConfig | None],
+    ) -> None:
+        """Initialize the parameter reader.
+
+        Args:
+            request: Callable performing a client request.
+            get_api_data: Callable returning the current API config data.
+
+        """
+        self._request = request
+        self._get_api_data = get_api_data
+
+    async def read_parameters(
+        self,
+        parameter_ids: list[str],
+    ) -> dict[str, EntityInfo]:
+        """Read specific parameters by their BSB-LAN parameter IDs.
+
+        Args:
+            parameter_ids: List of BSB-LAN parameter IDs to fetch.
+
+        Returns:
+            dict[str, EntityInfo]: Dictionary mapping parameter IDs to
+                EntityInfo objects.
+
+        Raises:
+            BSBLANError: If no parameter IDs are provided or request fails.
+
+        """
+        if not parameter_ids:
+            raise BSBLANError(ErrorMsg.NO_PARAMETER_IDS)
+
+        # Request the parameters from the device
+        params_string = ",".join(parameter_ids)
+        response_data = await self._request(params={"Parameter": params_string})
+
+        # Convert response to EntityInfo objects
+        result: dict[str, EntityInfo] = {}
+        for param_id in parameter_ids:
+            if param_id in response_data:
+                param_data = response_data[param_id]
+                if param_data and isinstance(param_data, dict):
+                    result[param_id] = EntityInfo.model_validate(param_data)
+
+        return result
+
+    def get_parameter_id(self, parameter_name: str) -> str | None:
+        """Look up the parameter ID for a given parameter name.
+
+        Args:
+            parameter_name: The parameter name (e.g., "current_temperature").
+
+        Returns:
+            str | None: The parameter ID if found, None otherwise.
+
+        """
+        api_data = self._get_api_data()
+        if not api_data:
+            return None
+
+        # Search through all sections for the parameter name
+        for section_params in api_data.values():
+            section_dict = cast("dict[str, str]", section_params)
+            for param_id, param_name in section_dict.items():
+                if param_name == parameter_name:
+                    return param_id
+
+        return None
+
+    def get_parameter_ids(self, parameter_names: list[str]) -> dict[str, str]:
+        """Look up parameter IDs for multiple parameter names.
+
+        Args:
+            parameter_names: List of parameter names to look up.
+
+        Returns:
+            dict[str, str]: Dictionary mapping parameter names to their IDs.
+                Only includes parameters that were found.
+
+        """
+        result: dict[str, str] = {}
+        for name in parameter_names:
+            param_id = self.get_parameter_id(name)
+            if param_id is not None:
+                result[name] = param_id
+        return result
+
+    async def read_parameters_by_name(
+        self,
+        parameter_names: list[str],
+    ) -> dict[str, EntityInfo]:
+        """Read specific parameters by their names.
+
+        Args:
+            parameter_names: List of parameter names to fetch.
+
+        Returns:
+            dict[str, EntityInfo]: Dictionary mapping parameter names to
+                EntityInfo objects. Only includes parameters that were found
+                and had valid data.
+
+        Raises:
+            BSBLANError: If no parameter names are provided, no IDs could be
+                resolved, or the client is not initialized.
+
+        """
+        if not parameter_names:
+            raise BSBLANError(ErrorMsg.NO_PARAMETER_NAMES)
+
+        if not self._get_api_data():
+            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
+
+        # Resolve names to IDs
+        name_to_id = self.get_parameter_ids(parameter_names)
+
+        if not name_to_id:
+            unknown_params = ", ".join(parameter_names)
+            msg = f"{ErrorMsg.PARAMETER_NAMES_NOT_RESOLVED}: {unknown_params}"
+            raise BSBLANError(msg)
+
+        # Fetch parameters by ID
+        param_ids = list(name_to_id.values())
+        id_results = await self.read_parameters(param_ids)
+
+        # Convert back to name-keyed dictionary
+        # id_to_name maps param_id -> param_name for requested params only
+        id_to_name = {v: k for k, v in name_to_id.items()}
+        return {
+            id_to_name[param_id]: entity_info
+            for param_id, entity_info in id_results.items()
+            if param_id in id_to_name
+        }

--- a/src/bsblan/_schedules.py
+++ b/src/bsblan/_schedules.py
@@ -1,0 +1,148 @@
+"""Heating and hot water schedule domain logic for BSB-LAN."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .constants import ErrorMsg, HeatingScheduleParams, HotWaterParams
+from .exceptions import BSBLANError
+from .models import HeatingTimeSwitchPrograms
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from .models import DaySchedule, DHWSchedule, HeatingSchedule
+
+
+class ScheduleManager:
+    """Read and write heating and hot water time switch programs."""
+
+    def __init__(  # noqa: PLR0913  # pylint: disable=too-many-arguments
+        self,
+        *,
+        request: Callable[..., Awaitable[dict[str, Any]]],
+        extract_params_summary: Callable[[dict[Any, Any]], dict[Any, Any]],
+        apply_include_filter: Callable[
+            [dict[str, str], list[str] | None], dict[str, str]
+        ],
+        validate_circuit: Callable[[int], None],
+        set_payload: Callable[[str, str], dict[str, Any]],
+        set_device_state: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        """Initialize the schedule manager.
+
+        Args:
+            request: Callable performing a client request.
+            extract_params_summary: Builds the request parameter summary.
+            apply_include_filter: Filters params by requested names.
+            validate_circuit: Validates a heating circuit number.
+            set_payload: Builds a set-parameter payload.
+            set_device_state: Sends a set-parameter request to the device.
+
+        """
+        self._request = request
+        self._extract_params_summary = extract_params_summary
+        self._apply_include_filter = apply_include_filter
+        self._validate_circuit = validate_circuit
+        self._set_payload = set_payload
+        self._set_device_state = set_device_state
+
+    async def heating_schedule(
+        self,
+        include: list[str] | None = None,
+        circuit: int = 1,
+    ) -> HeatingTimeSwitchPrograms:
+        """Get heating time switch programs for a specific circuit.
+
+        Args:
+            include: Optional list of day names to fetch.
+            circuit: The heating circuit number (1 or 2). Defaults to 1.
+
+        Returns:
+            HeatingTimeSwitchPrograms: Heating schedule information.
+
+        Raises:
+            BSBLANError: If no schedule parameters are available.
+
+        """
+        self._validate_circuit(circuit)
+        time_program_params = HeatingScheduleParams.TIME_PROGRAMS[circuit]
+
+        filtered_params = self._apply_include_filter(time_program_params, include)
+
+        params = self._extract_params_summary(filtered_params)
+        data = await self._request(params={"Parameter": params["string_par"]})
+        mapped_data = {
+            name: data[param_id]
+            for param_id, name in filtered_params.items()
+            if param_id in data
+        }
+
+        if not mapped_data:
+            raise BSBLANError(ErrorMsg.NO_HEATING_SCHEDULE_PARAMS)
+
+        return HeatingTimeSwitchPrograms.model_validate(mapped_data)
+
+    async def set_heating_schedule(
+        self,
+        schedule: HeatingSchedule,
+        circuit: int = 1,
+    ) -> None:
+        """Set heating time switch programs for a specific circuit.
+
+        Args:
+            schedule: HeatingSchedule object containing the weekly schedule.
+            circuit: The heating circuit number (1 or 2). Defaults to 1.
+
+        Raises:
+            BSBLANError: If no schedule is provided.
+
+        """
+        self._validate_circuit(circuit)
+        await self._write_day_schedules(
+            schedule,
+            HeatingScheduleParams.TIME_PROGRAMS[circuit],
+        )
+
+    async def set_hot_water_schedule(self, schedule: DHWSchedule) -> None:
+        """Set hot water time program schedules.
+
+        Args:
+            schedule: DHWSchedule object containing the weekly schedule.
+
+        Raises:
+            BSBLANError: If no schedule is provided.
+
+        """
+        await self._write_day_schedules(schedule, HotWaterParams.TIME_PROGRAMS)
+
+    async def _write_day_schedules(
+        self,
+        schedule: HeatingSchedule | DHWSchedule,
+        time_programs: dict[str, str],
+    ) -> None:
+        """Write populated day schedules using one request per day.
+
+        Args:
+            schedule: Weekly schedule object with per-day DaySchedule attrs.
+            time_programs: Mapping of parameter IDs to day names.
+
+        Raises:
+            BSBLANError: If no schedule is provided.
+
+        """
+        if not schedule.has_any_schedule():
+            raise BSBLANError(ErrorMsg.NO_SCHEDULE)
+
+        # Invert the param mapping to get day_name -> param_id
+        # Exclude standard_values as it's not a day of the week
+        day_param_map = {
+            v: k for k, v in time_programs.items() if v != "standard_values"
+        }
+
+        for day_name, param_id in day_param_map.items():
+            day_schedule: DaySchedule | None = getattr(schedule, day_name)
+            if day_schedule is not None:
+                await self._set_device_state(
+                    self._set_payload(param_id, day_schedule.to_bsblan_format()),
+                )

--- a/src/bsblan/_thermostat.py
+++ b/src/bsblan/_thermostat.py
@@ -1,0 +1,137 @@
+"""Thermostat write preparation for BSB-LAN."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .constants import CircuitConfig, Validation
+from .exceptions import BSBLANInvalidParameterError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ._temperature import TemperatureManager
+
+
+class ThermostatWriter:
+    """Prepare and validate thermostat write payloads."""
+
+    def __init__(
+        self,
+        *,
+        uses_pps_bus: Callable[[], bool],
+        temperature: TemperatureManager,
+        set_payload: Callable[[str, str], dict[str, Any]],
+    ) -> None:
+        """Initialize the thermostat writer.
+
+        Args:
+            uses_pps_bus: Returns whether the device uses the PPS bus.
+            temperature: Temperature manager for setpoint validation.
+            set_payload: Builds a set-parameter payload.
+
+        """
+        self._uses_pps_bus = uses_pps_bus
+        self._temperature = temperature
+        self._set_payload = set_payload
+
+    async def prepare_state(  # pylint: disable=too-many-arguments
+        self,
+        target_temperature: str | None,
+        hvac_mode: int | None,
+        circuit: int = 1,
+        target_temperature_high: str | float | None = None,
+        *,
+        cooling_operating_mode: int | None = None,
+    ) -> dict[str, Any]:
+        """Prepare the thermostat state for setting.
+
+        Args:
+            target_temperature (str | None): The target temperature to set.
+            hvac_mode (int | None): The HVAC mode to set as raw integer.
+            circuit: The heating circuit number (1 or 2).
+            target_temperature_high: The cooling comfort setpoint to set.
+            cooling_operating_mode: The cooling circuit operating mode to set
+                as raw integer.
+
+        Returns:
+            dict[str, Any]: The prepared state for the thermostat.
+
+        """
+        param_ids = self.thermostat_params(circuit)
+        state: dict[str, Any] = {}
+        if target_temperature is not None:
+            await self._temperature.validate_target_temperature(
+                target_temperature,
+                circuit,
+            )
+            state.update(
+                self._set_payload(param_ids["target_temperature"], target_temperature),
+            )
+        if target_temperature_high is not None:
+            param_id = param_ids.get("target_temperature_high")
+            if param_id is None:
+                parameter_name = "target_temperature_high"
+                raise BSBLANInvalidParameterError(parameter_name)
+            await self._temperature.validate_target_temperature_high(
+                target_temperature_high,
+                circuit,
+            )
+            state.update(
+                self._set_payload(param_id, str(target_temperature_high)),
+            )
+        if hvac_mode is not None:
+            self.validate_hvac_mode(hvac_mode)
+            hvac_value = str(hvac_mode)
+            if self._uses_pps_bus():
+                hvac_value = Validation.PPS_HVAC_MODE_TO_BSBLAN[hvac_mode]
+            state.update(
+                self._set_payload(param_ids["hvac_mode"], hvac_value),
+            )
+        if cooling_operating_mode is not None:
+            param_id = param_ids.get("cooling_operating_mode")
+            if param_id is None:
+                parameter_name = "cooling_operating_mode"
+                raise BSBLANInvalidParameterError(parameter_name)
+            self.validate_cooling_operating_mode(cooling_operating_mode)
+            state.update(
+                self._set_payload(param_id, str(cooling_operating_mode)),
+            )
+        return state
+
+    def thermostat_params(self, circuit: int) -> dict[str, str]:
+        """Return thermostat write parameters for the active bus type."""
+        if self._uses_pps_bus():
+            return {"target_temperature": "15004", "hvac_mode": "15000"}
+        return CircuitConfig.THERMOSTAT_PARAMS[circuit]
+
+    def validate_hvac_mode(self, hvac_mode: int) -> None:
+        """Validate the HVAC mode.
+
+        Args:
+            hvac_mode (int): The HVAC mode to validate. BSB/LPB accepts 0-3;
+                PPS accepts 0, 1, and 3.
+
+        Raises:
+            BSBLANInvalidParameterError: If the HVAC mode is invalid.
+
+        """
+        valid_modes = (
+            Validation.PPS_HVAC_MODES if self._uses_pps_bus() else Validation.HVAC_MODES
+        )
+        if hvac_mode not in valid_modes:
+            raise BSBLANInvalidParameterError(str(hvac_mode))
+
+    def validate_cooling_operating_mode(self, cooling_operating_mode: int) -> None:
+        """Validate the cooling circuit operating mode.
+
+        Args:
+            cooling_operating_mode (int): The mode to validate. Valid values
+                are 0=Protection, 1=Automatic, 2=Reduced, 3=Comfort.
+
+        Raises:
+            BSBLANInvalidParameterError: If the mode is invalid.
+
+        """
+        if cooling_operating_mode not in Validation.COOLING_OPERATING_MODES:
+            raise BSBLANInvalidParameterError(str(cooling_operating_mode))

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -16,6 +16,7 @@ from ._hot_water import HotWaterManager
 from ._parameters import ParameterReader
 from ._schedules import ScheduleManager
 from ._temperature import TemperatureManager
+from ._thermostat import ThermostatWriter
 from ._transport import BSBLANTransport
 from ._validation import SectionValidator
 from ._version import VersionResolver
@@ -106,6 +107,7 @@ class BSBLAN:
     _parameters: ParameterReader = field(init=False)
     _hot_water: HotWaterManager = field(init=False)
     _schedules: ScheduleManager = field(init=False)
+    _thermostat_writer: ThermostatWriter = field(init=False)
 
     def __post_init__(self) -> None:
         """Wire up internal collaborators after dataclass construction."""
@@ -152,6 +154,11 @@ class BSBLAN:
             validate_circuit=self._validate_circuit,
             set_payload=self._set_payload,
             set_device_state=self._set_device_state,
+        )
+        self._thermostat_writer = ThermostatWriter(
+            uses_pps_bus=lambda: self._uses_pps_bus,
+            temperature=self._temperature,
+            set_payload=self._set_payload,
         )
 
     async def __aenter__(self) -> Self:
@@ -904,7 +911,7 @@ class BSBLAN:
             error_msg=ErrorMsg.MULTI_PARAMETER,
         )
 
-        state = await self._prepare_thermostat_state(
+        state = await self._thermostat_writer.prepare_state(
             target_temperature,
             hvac_mode,
             circuit,
@@ -912,76 +919,6 @@ class BSBLAN:
             cooling_operating_mode=cooling_operating_mode,
         )
         await self._set_device_state(state)
-
-    async def _prepare_thermostat_state(  # pylint: disable=too-many-arguments
-        self,
-        target_temperature: str | None,
-        hvac_mode: int | None,
-        circuit: int = 1,
-        target_temperature_high: str | float | None = None,
-        *,
-        cooling_operating_mode: int | None = None,
-    ) -> dict[str, Any]:
-        """Prepare the thermostat state for setting.
-
-        Args:
-            target_temperature (str | None): The target temperature to set.
-            hvac_mode (int | None): The HVAC mode to set as raw integer.
-            circuit: The heating circuit number (1 or 2).
-            target_temperature_high: The cooling comfort setpoint to set.
-            cooling_operating_mode: The cooling circuit operating mode to set
-                as raw integer.
-
-        Returns:
-            dict[str, Any]: The prepared state for the thermostat.
-
-        """
-        param_ids = self._thermostat_params(circuit)
-        state: dict[str, Any] = {}
-        if target_temperature is not None:
-            await self._validate_target_temperature(
-                target_temperature,
-                circuit,
-            )
-            state.update(
-                self._set_payload(param_ids["target_temperature"], target_temperature),
-            )
-        if target_temperature_high is not None:
-            param_id = param_ids.get("target_temperature_high")
-            if param_id is None:
-                parameter_name = "target_temperature_high"
-                raise BSBLANInvalidParameterError(parameter_name)
-            await self._validate_target_temperature_high(
-                target_temperature_high,
-                circuit,
-            )
-            state.update(
-                self._set_payload(param_id, str(target_temperature_high)),
-            )
-        if hvac_mode is not None:
-            self._validate_hvac_mode(hvac_mode)
-            hvac_value = str(hvac_mode)
-            if self._uses_pps_bus:
-                hvac_value = Validation.PPS_HVAC_MODE_TO_BSBLAN[hvac_mode]
-            state.update(
-                self._set_payload(param_ids["hvac_mode"], hvac_value),
-            )
-        if cooling_operating_mode is not None:
-            param_id = param_ids.get("cooling_operating_mode")
-            if param_id is None:
-                parameter_name = "cooling_operating_mode"
-                raise BSBLANInvalidParameterError(parameter_name)
-            self._validate_cooling_operating_mode(cooling_operating_mode)
-            state.update(
-                self._set_payload(param_id, str(cooling_operating_mode)),
-            )
-        return state
-
-    def _thermostat_params(self, circuit: int) -> dict[str, str]:
-        """Return thermostat write parameters for the active bus type."""
-        if self._uses_pps_bus:
-            return {"target_temperature": "15004", "hvac_mode": "15000"}
-        return CircuitConfig.THERMOSTAT_PARAMS[circuit]
 
     async def _validate_target_temperature_high(
         self,
@@ -1017,37 +954,6 @@ class BSBLAN:
             target_temperature,
             circuit,
         )
-
-    def _validate_hvac_mode(self, hvac_mode: int) -> None:
-        """Validate the HVAC mode.
-
-        Args:
-            hvac_mode (int): The HVAC mode to validate. BSB/LPB accepts 0-3;
-                PPS accepts 0, 1, and 3.
-
-        Raises:
-            BSBLANInvalidParameterError: If the HVAC mode is invalid.
-
-        """
-        valid_modes = (
-            Validation.PPS_HVAC_MODES if self._uses_pps_bus else Validation.HVAC_MODES
-        )
-        if hvac_mode not in valid_modes:
-            raise BSBLANInvalidParameterError(str(hvac_mode))
-
-    def _validate_cooling_operating_mode(self, cooling_operating_mode: int) -> None:
-        """Validate the cooling circuit operating mode.
-
-        Args:
-            cooling_operating_mode (int): The mode to validate. Valid values
-                are 0=Protection, 1=Automatic, 2=Reduced, 3=Comfort.
-
-        Raises:
-            BSBLANInvalidParameterError: If the mode is invalid.
-
-        """
-        if cooling_operating_mode not in Validation.COOLING_OPERATING_MODES:
-            raise BSBLANInvalidParameterError(str(cooling_operating_mode))
 
     def _validate_time_format(self, time_value: str) -> None:
         """Validate the time format.

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 import aiohttp
 from aiohttp.hdrs import METH_POST
 
+from ._parameters import ParameterReader
 from ._temperature import TemperatureManager
 from ._transport import BSBLANTransport
 from ._validation import SectionValidator
@@ -108,6 +109,7 @@ class BSBLAN:
     _version_resolver: VersionResolver = field(init=False)
     _temperature: TemperatureManager = field(init=False)
     _validator: SectionValidator = field(init=False)
+    _parameters: ParameterReader = field(init=False)
 
     def __post_init__(self) -> None:
         """Wire up internal collaborators after dataclass construction."""
@@ -131,6 +133,10 @@ class BSBLAN:
             get_api_data=lambda: self._api_data,
             should_extract_temperature_unit=self._should_extract_temperature_unit,
             extract_temperature_unit=self._extract_temperature_unit_from_response,
+        )
+        self._parameters = ParameterReader(
+            request=lambda **kw: self._request(**kw),  # noqa: PLW0108
+            get_api_data=lambda: self._api_data,
         )
 
     async def __aenter__(self) -> Self:
@@ -1466,22 +1472,7 @@ class BSBLAN:
             BSBLANError: If no parameter IDs are provided or request fails.
 
         """
-        if not parameter_ids:
-            raise BSBLANError(ErrorMsg.NO_PARAMETER_IDS)
-
-        # Request the parameters from the device
-        params_string = ",".join(parameter_ids)
-        response_data = await self._request(params={"Parameter": params_string})
-
-        # Convert response to EntityInfo objects
-        result: dict[str, EntityInfo] = {}
-        for param_id in parameter_ids:
-            if param_id in response_data:
-                param_data = response_data[param_id]
-                if param_data and isinstance(param_data, dict):
-                    result[param_id] = EntityInfo.model_validate(param_data)
-
-        return result
+        return await self._parameters.read_parameters(parameter_ids)
 
     def get_parameter_id(self, parameter_name: str) -> str | None:
         """Look up the parameter ID for a given parameter name.
@@ -1500,17 +1491,7 @@ class BSBLAN:
             str | None: The parameter ID if found, None otherwise.
 
         """
-        if not self._api_data:
-            return None
-
-        # Search through all sections for the parameter name
-        for section_params in self._api_data.values():
-            section_dict = cast("dict[str, str]", section_params)
-            for param_id, param_name in section_dict.items():
-                if param_name == parameter_name:
-                    return param_id
-
-        return None
+        return self._parameters.get_parameter_id(parameter_name)
 
     def get_parameter_ids(self, parameter_names: list[str]) -> dict[str, str]:
         """Look up parameter IDs for multiple parameter names.
@@ -1527,12 +1508,7 @@ class BSBLAN:
                 Only includes parameters that were found.
 
         """
-        result: dict[str, str] = {}
-        for name in parameter_names:
-            param_id = self.get_parameter_id(name)
-            if param_id is not None:
-                result[name] = param_id
-        return result
+        return self._parameters.get_parameter_ids(parameter_names)
 
     async def read_parameters_by_name(
         self,
@@ -1564,29 +1540,4 @@ class BSBLAN:
                 or the client is not initialized.
 
         """
-        if not parameter_names:
-            raise BSBLANError(ErrorMsg.NO_PARAMETER_NAMES)
-
-        if not self._api_data:
-            raise BSBLANError(ErrorMsg.API_DATA_NOT_INITIALIZED)
-
-        # Resolve names to IDs
-        name_to_id = self.get_parameter_ids(parameter_names)
-
-        if not name_to_id:
-            unknown_params = ", ".join(parameter_names)
-            msg = f"{ErrorMsg.PARAMETER_NAMES_NOT_RESOLVED}: {unknown_params}"
-            raise BSBLANError(msg)
-
-        # Fetch parameters by ID
-        param_ids = list(name_to_id.values())
-        id_results = await self.read_parameters(param_ids)
-
-        # Convert back to name-keyed dictionary
-        # id_to_name maps param_id -> param_name for requested params only
-        id_to_name = {v: k for k, v in name_to_id.items()}
-        return {
-            id_to_name[param_id]: entity_info
-            for param_id, entity_info in id_results.items()
-            if param_id in id_to_name
-        }
+        return await self._parameters.read_parameters_by_name(parameter_names)

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -14,6 +14,7 @@ from aiohttp.hdrs import METH_POST
 
 from ._hot_water import HotWaterManager
 from ._parameters import ParameterReader
+from ._schedules import ScheduleManager
 from ._temperature import TemperatureManager
 from ._transport import BSBLANTransport
 from ._validation import SectionValidator
@@ -25,8 +26,6 @@ from .constants import (
     APIConfig,
     CircuitConfig,
     ErrorMsg,
-    HeatingScheduleParams,
-    HotWaterParams,
     Validation,
 )
 from .exceptions import (
@@ -36,7 +35,6 @@ from .exceptions import (
 )
 from .models import (
     ApiVersion,
-    DaySchedule,
     Device,
     DeviceTime,
     DHWSchedule,
@@ -107,6 +105,7 @@ class BSBLAN:
     _validator: SectionValidator = field(init=False)
     _parameters: ParameterReader = field(init=False)
     _hot_water: HotWaterManager = field(init=False)
+    _schedules: ScheduleManager = field(init=False)
 
     def __post_init__(self) -> None:
         """Wire up internal collaborators after dataclass construction."""
@@ -141,6 +140,16 @@ class BSBLAN:
             apply_include_filter=self._apply_include_filter,
             request_named_params=self._request_named_params,
             validate_single_parameter=self._validate_single_parameter,
+            set_payload=self._set_payload,
+            set_device_state=self._set_device_state,
+        )
+        self._schedules = ScheduleManager(
+            request=lambda **kw: self._request(**kw),  # noqa: PLW0108
+            extract_params_summary=(
+                lambda d: self._extract_params_summary(d)  # noqa: PLW0108
+            ),
+            apply_include_filter=self._apply_include_filter,
+            validate_circuit=self._validate_circuit,
             set_payload=self._set_payload,
             set_device_state=self._set_device_state,
         )
@@ -1193,23 +1202,7 @@ class BSBLAN:
             HeatingTimeSwitchPrograms: Heating schedule information.
 
         """
-        self._validate_circuit(circuit)
-        time_program_params = HeatingScheduleParams.TIME_PROGRAMS[circuit]
-
-        filtered_params = self._apply_include_filter(time_program_params, include)
-
-        params = self._extract_params_summary(filtered_params)
-        data = await self._request(params={"Parameter": params["string_par"]})
-        mapped_data = {
-            name: data[param_id]
-            for param_id, name in filtered_params.items()
-            if param_id in data
-        }
-
-        if not mapped_data:
-            raise BSBLANError(ErrorMsg.NO_HEATING_SCHEDULE_PARAMS)
-
-        return HeatingTimeSwitchPrograms.model_validate(mapped_data)
+        return await self._schedules.heating_schedule(include, circuit)
 
     async def set_heating_schedule(
         self,
@@ -1229,23 +1222,7 @@ class BSBLAN:
             BSBLANError: If no schedule is provided.
 
         """
-        self._validate_circuit(circuit)
-
-        if not schedule.has_any_schedule():
-            raise BSBLANError(ErrorMsg.NO_SCHEDULE)
-
-        day_param_map = {
-            v: k
-            for k, v in HeatingScheduleParams.TIME_PROGRAMS[circuit].items()
-            if v != "standard_values"
-        }
-
-        for day_name, param_id in day_param_map.items():
-            day_schedule: DaySchedule | None = getattr(schedule, day_name)
-            if day_schedule is not None:
-                await self._set_device_state(
-                    self._set_payload(param_id, day_schedule.to_bsblan_format()),
-                )
+        await self._schedules.set_heating_schedule(schedule, circuit)
 
     async def set_hot_water(self, params: SetHotWaterParam) -> None:
         """Change the state of the hot water system through BSB-Lan.
@@ -1290,23 +1267,7 @@ class BSBLAN:
             BSBLANError: If no schedule is provided.
 
         """
-        if not schedule.has_any_schedule():
-            raise BSBLANError(ErrorMsg.NO_SCHEDULE)
-
-        # Invert DHW_TIME_PROGRAM_PARAMS to get day_name -> param_id mapping
-        # Exclude standard_values as it's not a day of the week
-        day_param_map = {
-            v: k
-            for k, v in HotWaterParams.TIME_PROGRAMS.items()
-            if v != "standard_values"
-        }
-
-        for day_name, param_id in day_param_map.items():
-            day_schedule: DaySchedule | None = getattr(schedule, day_name)
-            if day_schedule is not None:
-                await self._set_device_state(
-                    self._set_payload(param_id, day_schedule.to_bsblan_format()),
-                )
+        await self._schedules.set_hot_water_schedule(schedule)
 
     def _prepare_hot_water_state(
         self,

--- a/src/bsblan/bsblan.py
+++ b/src/bsblan/bsblan.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 import aiohttp
 from aiohttp.hdrs import METH_POST
 
+from ._hot_water import HotWaterManager
 from ._parameters import ParameterReader
 from ._temperature import TemperatureManager
 from ._transport import BSBLANTransport
@@ -68,11 +69,6 @@ SectionLiteral = Literal[
     "staticValues_circuit2",
 ]
 
-# TypeVar for hot water data models
-HotWaterDataT = TypeVar(
-    "HotWaterDataT", HotWaterState, HotWaterConfig, HotWaterSchedule
-)
-
 # TypeVar for section data models
 SectionDataT = TypeVar("SectionDataT", State, Sensor, StaticState, Info)
 
@@ -110,6 +106,7 @@ class BSBLAN:
     _temperature: TemperatureManager = field(init=False)
     _validator: SectionValidator = field(init=False)
     _parameters: ParameterReader = field(init=False)
+    _hot_water: HotWaterManager = field(init=False)
 
     def __post_init__(self) -> None:
         """Wire up internal collaborators after dataclass construction."""
@@ -137,6 +134,15 @@ class BSBLAN:
         self._parameters = ParameterReader(
             request=lambda **kw: self._request(**kw),  # noqa: PLW0108
             get_api_data=lambda: self._api_data,
+        )
+        self._hot_water = HotWaterManager(
+            ensure_group_validated=self._ensure_hot_water_group_validated,
+            get_param_cache=lambda: self._validator.hot_water_param_cache,
+            apply_include_filter=self._apply_include_filter,
+            request_named_params=self._request_named_params,
+            validate_single_parameter=self._validate_single_parameter,
+            set_payload=self._set_payload,
+            set_device_state=self._set_device_state,
         )
 
     async def __aenter__(self) -> Self:
@@ -1077,55 +1083,6 @@ class BSBLAN:
         response = await self._request(base_path="/JS", data=state)
         logger.debug("Response for setting: %s", response)
 
-    async def _fetch_hot_water_data(
-        self,
-        param_filter: set[str],
-        model_class: type[HotWaterDataT],
-        error_msg: str,
-        group_name: str,
-        include: list[str] | None = None,
-    ) -> HotWaterDataT:
-        """Fetch hot water data for a specific parameter set.
-
-        This is a generic helper method that fetches hot water parameters
-        based on the provided filter and returns the appropriate model.
-        It uses granular lazy loading to validate only the specific param group.
-
-        Args:
-            param_filter: Set of parameter IDs to fetch.
-            model_class: The dataclass type to deserialize the response into.
-            error_msg: Error message if no parameters are available.
-            group_name: Name of the param group for lazy validation tracking.
-            include: Optional list of parameter names to fetch. If None,
-                fetches all parameters in the group.
-
-        Returns:
-            The populated model instance.
-
-        Raises:
-            BSBLANError: If no parameters are available for the filter.
-
-        """
-        # Granular lazy load: validate only this param group on first access
-        # Pass include filter so we only validate requested params
-        await self._ensure_hot_water_group_validated(group_name, param_filter, include)
-
-        # Use cached validated params
-        filtered_params = {
-            param_id: param_name
-            for param_id, param_name in self._validator.hot_water_param_cache.items()
-            if param_id in param_filter
-        }
-
-        # Apply include filter if specified
-        filtered_params = self._apply_include_filter(filtered_params, include)
-
-        if not filtered_params:
-            raise BSBLANError(error_msg)
-
-        data = await self._request_named_params(filtered_params)
-        return model_class.model_validate(data)
-
     async def hot_water_state(self, include: list[str] | None = None) -> HotWaterState:
         """Get essential hot water state for frequent polling.
 
@@ -1152,13 +1109,7 @@ class BSBLAN:
             )
 
         """
-        return await self._fetch_hot_water_data(
-            param_filter=HotWaterParams.ESSENTIAL,
-            model_class=HotWaterState,
-            error_msg="No essential hot water parameters available",
-            group_name="essential",
-            include=include,
-        )
+        return await self._hot_water.state(include)
 
     async def hot_water_config(
         self, include: list[str] | None = None
@@ -1192,13 +1143,7 @@ class BSBLAN:
             )
 
         """
-        return await self._fetch_hot_water_data(
-            param_filter=HotWaterParams.CONFIG,
-            model_class=HotWaterConfig,
-            error_msg="No hot water configuration parameters available",
-            group_name="config",
-            include=include,
-        )
+        return await self._hot_water.config(include)
 
     async def hot_water_schedule(
         self, include: list[str] | None = None
@@ -1228,13 +1173,7 @@ class BSBLAN:
             )
 
         """
-        return await self._fetch_hot_water_data(
-            param_filter=HotWaterParams.SCHEDULE,
-            model_class=HotWaterSchedule,
-            error_msg="No hot water schedule parameters available",
-            group_name="schedule",
-            include=include,
-        )
+        return await self._hot_water.schedule(include)
 
     async def heating_schedule(
         self,
@@ -1324,44 +1263,7 @@ class BSBLAN:
             BSBLANError: If multiple parameters are set or no parameter is set.
 
         """
-        # Validate only one parameter is being set
-        time_program_params: list[str] = []
-        if params.dhw_time_programs:
-            programs = params.dhw_time_programs
-            time_program_params.extend(
-                prog
-                for prog in [
-                    programs.monday,
-                    programs.tuesday,
-                    programs.wednesday,
-                    programs.thursday,
-                    programs.friday,
-                    programs.saturday,
-                    programs.sunday,
-                    programs.standard_values,
-                ]
-                if prog
-            )
-
-        self._validate_single_parameter(
-            params.nominal_setpoint,
-            params.reduced_setpoint,
-            params.nominal_setpoint_max,
-            params.operating_mode,
-            params.eco_mode_selection,
-            params.dhw_charging_priority,
-            params.legionella_function_setpoint,
-            params.legionella_function_periodicity,
-            params.legionella_function_day,
-            params.legionella_function_time,
-            params.legionella_function_dwelling_time,
-            params.operating_mode_changeover,
-            *time_program_params,
-            error_msg=ErrorMsg.MULTI_PARAMETER,
-        )
-
-        state = self._prepare_hot_water_state(params)
-        await self._set_device_state(state)
+        await self._hot_water.set_hot_water(params)
 
     async def set_hot_water_schedule(self, schedule: DHWSchedule) -> None:
         """Set hot water time program schedules.
@@ -1422,24 +1324,7 @@ class BSBLAN:
             BSBLANError: If no state is provided.
 
         """
-        state: dict[str, Any] = {}
-
-        # Process all mapped parameters using constants
-        for param_id, attr_name in HotWaterParams.SETTABLE.items():
-            value = getattr(params, attr_name)
-            if value is not None:
-                state.update(self._set_payload(param_id, str(value)))
-
-        # Process time programs if provided using constants
-        if params.dhw_time_programs:
-            for param_id, attr_name in HotWaterParams.TIME_PROGRAMS.items():
-                value = getattr(params.dhw_time_programs, attr_name)
-                if value is not None:
-                    state.update(self._set_payload(param_id, value))
-
-        if not state:
-            raise BSBLANError(ErrorMsg.NO_STATE)
-        return state
+        return self._hot_water.prepare_state(params)
 
     # -------------------------------------------------------------------------
     # Low-level parameter access methods

--- a/tests/test_backoff_retry.py
+++ b/tests/test_backoff_retry.py
@@ -12,7 +12,7 @@ from aresponses import ResponsesMockServer
 
 from bsblan import BSBLAN
 from bsblan.bsblan import BSBLANConfig
-from bsblan.exceptions import BSBLANConnectionError
+from bsblan.exceptions import BSBLANAuthError, BSBLANConnectionError
 
 
 @pytest.mark.asyncio
@@ -137,6 +137,42 @@ async def test_no_retry_on_404_giveup(aresponses: ResponsesMockServer) -> None:
         config = BSBLANConfig(host="example.com")
         bsblan = BSBLAN(config, session=session)
         with pytest.raises(BSBLANConnectionError):
+            await bsblan._request()
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_401_auth_error(aresponses: ResponsesMockServer) -> None:
+    """Test that 401 responses raise BSBLANAuthError without retrying."""
+    # Only one response registered - a retry would find no response and fail
+    aresponses.add(
+        "example.com",
+        "/JQ",
+        "POST",
+        aresponses.Response(status=401, text="Unauthorized"),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        config = BSBLANConfig(host="example.com")
+        bsblan = BSBLAN(config, session=session)
+        with pytest.raises(BSBLANAuthError):
+            await bsblan._request()
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_403_auth_error(aresponses: ResponsesMockServer) -> None:
+    """Test that 403 responses raise BSBLANAuthError without retrying."""
+    # Only one response registered - a retry would find no response and fail
+    aresponses.add(
+        "example.com",
+        "/JQ",
+        "POST",
+        aresponses.Response(status=403, text="Forbidden"),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        config = BSBLANConfig(host="example.com")
+        bsblan = BSBLAN(config, session=session)
+        with pytest.raises(BSBLANAuthError):
             await bsblan._request()
 
 


### PR DESCRIPTION
This pull request introduces three new prompt files for the experimental OpenSpec workflow and refines the validation hook logic to improve performance and reliability. The new prompts define clear, guardrailed behaviors for "apply," "archive," and "explore" actions, supporting a more structured and user-friendly workflow. The validation hook is updated to only run heavy checks for relevant code/config file edits, reducing unnecessary validation runs.

**OpenSpec Workflow Prompts**

* Added `.github/prompts/opsx-apply.prompt.md`: Defines the step-by-step process for implementing tasks from an OpenSpec change, including change selection, status checking, task implementation, and progress reporting. Includes strong guardrails and integration with store selection.
* Added `.github/prompts/opsx-archive.prompt.md`: Outlines the process for archiving a completed change, including user prompts for ambiguous cases, artifact and task completion checks, delta spec sync assessment, and clear output summaries with warnings if needed.
* Added `.github/prompts/opsx-explore.prompt.md`: Establishes an "explore mode" stance for deep thinking, investigation, and requirements clarification, with strict rules against implementation and a focus on visual, adaptive, and grounded exploration.

**Validation Hook Improvements**

* `.github/hooks/run_validation_after_edits.sh`:
  - Refactored to only run the Python validation suite when code or config files are edited, skipping for docs, markdown, or memory edits. This reduces unnecessary validation runs. [[1]](diffhunk://#diff-aabf264d1186014ef7bd010f0fcdcd6abc12c57a150df974816391e5fe9a3dcdL9-R27) [[2]](diffhunk://#diff-aabf264d1186014ef7bd010f0fcdcd6abc12c57a150df974816391e5fe9a3dcdL46-R70)
  - Updated to set `SKIP=no-commit-to-branch` when running `prek` for improved pre-commit handling.