### PR TITLE
Add new exception types for unsupported features and responses

### DIFF
--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -13,3 +13,11 @@ Custom exceptions raised by the library.
 ## BSBLANAuthError
 
 ::: bsblan.BSBLANAuthError
+
+## BSBLANUnsupportedFeatureError
+
+::: bsblan.BSBLANUnsupportedFeatureError
+
+## BSBLANMalformedResponseError
+
+::: bsblan.BSBLANMalformedResponseError

--- a/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/.openspec.yaml
@@ -1,0 +1,3 @@
+---
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/design.md
+++ b/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`python-bsblan` currently exposes a single generic `BSBLANError` for a wide
+range of failure modes. Two of them are semantically opposite from a retry
+standpoint:
+
+- **Unsupported schedule** — the device does not expose the requested
+  time-program parameters. In `_schedules.heating_schedule()` this raises
+  `BSBLANError(ErrorMsg.NO_HEATING_SCHEDULE_PARAMS)`, and in
+  `_hot_water._get_filtered_data()` it raises `BSBLANError(error_msg)` for the
+  hot-water schedule group. This is a **permanent** condition.
+- **Malformed response** — the transport cannot decode or JSON-parse the body.
+  In `_transport.request_with_retry()` this is caught from `ValueError` /
+  `UnicodeDecodeError` and re-raised as
+  `BSBLANError(ErrorMsg.INVALID_RESPONSE.format(e))`. This is a **transient**
+  condition.
+
+Because both surface as `BSBLANError`, a downstream integration (Home Assistant)
+cannot decide whether to retry. It must either stop retrying (losing recovery
+from transient malformed responses) or retry forever (uselessly hammering a
+device that will never support a schedule after a write).
+
+The library's own `backoff` decorator only retries `TimeoutError` and
+`aiohttp.ClientError`, so `BSBLANError` is never retried inside the library; the
+retry decision lives in the consumer. The fix is therefore an additive exception
+taxonomy, not a change to the transport retry policy.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let callers distinguish permanent unsupported-feature failures from transient
+  malformed-response failures by `except` type.
+- Keep the change fully backward compatible with existing `except BSBLANError`
+  handlers.
+- Reuse existing `ErrorMsg` strings; no message wording changes.
+
+**Non-Goals:**
+- Changing the transport-level `backoff` retry policy or which HTTP statuses are
+  retried (`client-retry-policy` is unchanged).
+- Adding automatic retry logic inside the library for schedules.
+- Reclassifying other existing `BSBLANError` raise sites beyond schedule reads
+  and malformed-response parsing.
+
+## Decisions
+
+**Decision: Two new subclasses of `BSBLANError`.**
+Add `BSBLANUnsupportedFeatureError` (permanent) and
+`BSBLANMalformedResponseError` (transient), both subclassing `BSBLANError`.
+Subclassing preserves backward compatibility: any existing `except BSBLANError`
+keeps catching them.
+- *Alternative considered:* a single new error with a `retryable: bool`
+  attribute. Rejected — attribute inspection is less idiomatic than `except`
+  type matching and easier to get wrong at call sites.
+- *Alternative considered:* schedule-specific name (e.g.
+  `BSBLANUnsupportedScheduleError`). Chose the more general
+  `BSBLANUnsupportedFeatureError` because the same permanent semantics apply to
+  both heating and hot-water schedule reads and can extend to other
+  unsupported-parameter cases later.
+
+**Decision: Raise the permanent error at the schedule-read guard sites.**
+Replace the bare `BSBLANError(...)` at
+`_schedules.heating_schedule()` (no mapped data) and the hot-water schedule
+branch in `_hot_water._get_filtered_data()` with
+`BSBLANUnsupportedFeatureError`, keeping the existing `ErrorMsg` text. The
+hot-water helper is shared by state/config/schedule reads, so scope the new
+error to the schedule group only (via `group_name == "schedule"`) to avoid
+reclassifying unrelated state/config failures.
+
+**Decision: Raise the transient error at the transport parse site.**
+In `_transport.request_with_retry()`, replace the
+`raise BSBLANError(msg)` in the `(ValueError, UnicodeDecodeError)` handler with
+`raise BSBLANMalformedResponseError(msg)`, reusing
+`ErrorMsg.INVALID_RESPONSE`.
+
+**Decision: Export the new exceptions from the package.**
+Add both classes to `bsblan.exceptions` and to the package `__all__` /
+re-exports so consumers can import them from the top-level `bsblan` namespace.
+
+## Risks / Trade-offs
+
+- **[Consumers catching the narrow generic message string]** → Mitigation:
+  messages are unchanged; only the concrete type is narrower. Broad
+  `except BSBLANError` still works.
+- **[Over-scoping the hot-water helper]** → Mitigation: gate the new error on the
+  schedule group so state/config reads keep raising the existing generic error
+  and existing tests stay green.
+- **[Missed raise site]** → Mitigation: grep for `NO_HEATING_SCHEDULE_PARAMS`,
+  the hot-water schedule `error_msg`, and `INVALID_RESPONSE` to confirm all
+  targeted sites are updated; add tests asserting the concrete types.
+
+## Migration Plan
+
+Additive, no migration required. Release as a minor version. Consumers may
+optionally add narrower `except BSBLANUnsupportedFeatureError` /
+`except BSBLANMalformedResponseError` handlers; existing code is unaffected.
+
+## Open Questions
+
+- Final class names: `BSBLANUnsupportedFeatureError` vs
+  `BSBLANUnsupportedScheduleError`. Proposed the broader name; confirm during
+  review.

--- a/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/proposal.md
+++ b/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+In python-bsblan 6.1.6 both an *unsupported schedule* (a device that will never
+return the requested time-program parameters) and a *malformed response* (a
+transient decode/parse failure) are surfaced as the same generic `BSBLANError`.
+Downstream integrations such as Home Assistant cannot tell them apart by
+exception type, so they must choose between stopping retries on a transient
+malformed response or retrying an unsupported schedule indefinitely after a
+write. A dedicated exception taxonomy is needed at the library level to make the
+permanent-vs-transient distinction explicit.
+
+## What Changes
+
+- Add a dedicated **permanent** exception `BSBLANUnsupportedFeatureError`
+  (subclass of `BSBLANError`) raised when a device does not expose the requested
+  schedule parameters, so callers know retrying will never succeed.
+- Add a dedicated **transient** exception `BSBLANMalformedResponseError`
+  (subclass of `BSBLANError`) raised when a response body cannot be decoded or
+  parsed as valid JSON, signalling that a retry may succeed.
+- Raise `BSBLANUnsupportedFeatureError` in the heating- and hot-water-schedule
+  read paths where a bare `BSBLANError` is currently raised for absent schedule
+  parameters.
+- Raise `BSBLANMalformedResponseError` in the transport layer where invalid
+  JSON / decode errors are currently wrapped in a bare `BSBLANError`.
+- Both new exceptions subclass `BSBLANError`, so existing `except BSBLANError`
+  handlers keep working (non-breaking).
+
+## Capabilities
+
+### New Capabilities
+- `error-classification`: A library exception taxonomy that distinguishes
+  permanent unsupported-feature failures from transient malformed-response
+  failures, letting callers make correct retry decisions.
+
+### Modified Capabilities
+<!-- No existing spec's requirements change; client-retry-policy behavior is unaffected. -->
+
+## Impact
+
+- `src/bsblan/exceptions.py`: two new exception classes.
+- `src/bsblan/_schedules.py` and `src/bsblan/_hot_water.py`: raise the new
+  unsupported-feature error for absent schedule parameters.
+- `src/bsblan/_transport.py`: raise the new malformed-response error for
+  decode/parse failures.
+- `src/bsblan/constants.py`: no new messages required; existing `ErrorMsg`
+  entries are reused.
+- `tests/`: new coverage asserting the specific exception types are raised.
+- Public API: additive only. Consumers relying on `BSBLANError` are unaffected;
+  consumers can opt into finer-grained handling.

--- a/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/specs/error-classification/spec.md
+++ b/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/specs/error-classification/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Unsupported schedules raise a permanent error
+
+The client SHALL raise `BSBLANUnsupportedFeatureError` (a subclass of
+`BSBLANError`) when a schedule read cannot proceed because the device exposes no
+schedule parameters for the requested feature. This error MUST signal a
+permanent condition so callers know that retrying the same request will never
+succeed.
+
+#### Scenario: Heating schedule parameters absent
+
+- **WHEN** `heating_schedule()` is called for a circuit whose time-program
+  parameters are not present in the device response (no schedule parameters can
+  be mapped)
+- **THEN** the client raises `BSBLANUnsupportedFeatureError`
+- **AND** the raised exception is also an instance of `BSBLANError`
+
+#### Scenario: Hot water schedule parameters absent
+
+- **WHEN** `schedule()` is called on a device that exposes no hot-water
+  time-program parameters after include filtering
+- **THEN** the client raises `BSBLANUnsupportedFeatureError`
+- **AND** the raised exception is also an instance of `BSBLANError`
+
+### Requirement: Malformed responses raise a transient error
+
+The client SHALL raise `BSBLANMalformedResponseError` (a subclass of
+`BSBLANError`) when a device response body cannot be decoded or parsed as valid
+JSON. This error MUST signal a transient condition so callers know that a retry
+may succeed.
+
+#### Scenario: Response body is not valid JSON
+
+- **WHEN** a request receives an HTTP `200` response whose body cannot be parsed
+  as JSON
+- **THEN** the client raises `BSBLANMalformedResponseError`
+- **AND** the raised exception is also an instance of `BSBLANError`
+
+### Requirement: New exceptions preserve backward compatibility
+
+Both `BSBLANUnsupportedFeatureError` and `BSBLANMalformedResponseError` SHALL
+subclass `BSBLANError` so that existing `except BSBLANError` handlers continue to
+catch them without modification.
+
+#### Scenario: Existing broad handler still catches new errors
+
+- **WHEN** code catches `BSBLANError` around a call that raises either
+  `BSBLANUnsupportedFeatureError` or `BSBLANMalformedResponseError`
+- **THEN** the exception is caught by the `BSBLANError` handler

--- a/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/tasks.md
+++ b/openspec/changes/archive/2026-07-12-distinguish-schedule-error-types/tasks.md
@@ -1,0 +1,28 @@
+## 1. Exceptions
+
+- [x] 1.1 Add `BSBLANUnsupportedFeatureError(BSBLANError)` to `src/bsblan/exceptions.py` with a docstring describing it as a permanent (non-retryable) condition.
+- [x] 1.2 Add `BSBLANMalformedResponseError(BSBLANError)` to `src/bsblan/exceptions.py` with a docstring describing it as a transient (retryable) condition.
+- [x] 1.3 Import and re-export both new exceptions in `src/bsblan/__init__.py` and add them to `__all__`.
+
+## 2. Schedule read paths (permanent error)
+
+- [x] 2.1 In `src/bsblan/_schedules.py` `heating_schedule()`, raise `BSBLANUnsupportedFeatureError(ErrorMsg.NO_HEATING_SCHEDULE_PARAMS)` when no schedule parameters are mapped (replace the bare `BSBLANError`).
+- [x] 2.2 In `src/bsblan/_hot_water.py` `fetch_data()`, raise `BSBLANUnsupportedFeatureError(error_msg)` when the schedule group (`group_name == "schedule"`) has no filtered params, keeping other groups on the existing generic error.
+- [x] 2.3 Update the `Raises:` docstrings on the affected schedule methods to reference the new exception type.
+
+## 3. Transport parse path (transient error)
+
+- [x] 3.1 In `src/bsblan/_transport.py` `request_with_retry()`, raise `BSBLANMalformedResponseError(msg)` from the `(ValueError, UnicodeDecodeError)` handler (replace the bare `BSBLANError`), reusing `ErrorMsg.INVALID_RESPONSE`.
+- [x] 3.2 Update the `Raises:` docstring on `request_with_retry()` to reference the new exception type.
+
+## 4. Tests
+
+- [x] 4.1 Add a test asserting `heating_schedule()` raises `BSBLANUnsupportedFeatureError` when schedule params are absent, and that it is also a `BSBLANError`.
+- [x] 4.2 Add a test asserting hot-water `schedule()` raises `BSBLANUnsupportedFeatureError` when schedule params are absent.
+- [x] 4.3 Add a test asserting a non-JSON / undecodable response raises `BSBLANMalformedResponseError` and that it is also a `BSBLANError`.
+- [x] 4.4 Verify existing state/config hot-water tests still raise the generic `BSBLANError` (no regression from the group gating).
+
+## 5. Documentation & validation
+
+- [x] 5.1 Document the two new exceptions in `docs/api/exceptions.md`.
+- [x] 5.2 Run `uv run prek run --all-files` and `uv run pytest --cov=src/bsblan --cov-report=term-missing`; ensure total coverage stays >= 95% and patch coverage is 100%.

--- a/openspec/specs/error-classification/spec.md
+++ b/openspec/specs/error-classification/spec.md
@@ -1,0 +1,59 @@
+# error-classification
+
+## Purpose
+
+A library exception taxonomy that distinguishes permanent unsupported-feature
+failures from transient malformed-response failures, letting callers make
+correct retry decisions. Both new exceptions subclass `BSBLANError` so existing
+broad handlers keep working.
+
+## Requirements
+
+### Requirement: Unsupported schedules raise a permanent error
+
+The client SHALL raise `BSBLANUnsupportedFeatureError` (a subclass of
+`BSBLANError`) when a schedule read cannot proceed because the device exposes no
+schedule parameters for the requested feature. This error MUST signal a
+permanent condition so callers know that retrying the same request will never
+succeed.
+
+#### Scenario: Heating schedule parameters absent
+
+- **WHEN** `heating_schedule()` is called for a circuit whose time-program
+  parameters are not present in the device response (no schedule parameters can
+  be mapped)
+- **THEN** the client raises `BSBLANUnsupportedFeatureError`
+- **AND** the raised exception is also an instance of `BSBLANError`
+
+#### Scenario: Hot water schedule parameters absent
+
+- **WHEN** `schedule()` is called on a device that exposes no hot-water
+  time-program parameters after include filtering
+- **THEN** the client raises `BSBLANUnsupportedFeatureError`
+- **AND** the raised exception is also an instance of `BSBLANError`
+
+### Requirement: Malformed responses raise a transient error
+
+The client SHALL raise `BSBLANMalformedResponseError` (a subclass of
+`BSBLANError`) when a device response body cannot be decoded or parsed as valid
+JSON. This error MUST signal a transient condition so callers know that a retry
+may succeed.
+
+#### Scenario: Response body is not valid JSON
+
+- **WHEN** a request receives an HTTP `200` response whose body cannot be parsed
+  as JSON
+- **THEN** the client raises `BSBLANMalformedResponseError`
+- **AND** the raised exception is also an instance of `BSBLANError`
+
+### Requirement: New exceptions preserve backward compatibility
+
+Both `BSBLANUnsupportedFeatureError` and `BSBLANMalformedResponseError` SHALL
+subclass `BSBLANError` so that existing `except BSBLANError` handlers continue to
+catch them without modification.
+
+#### Scenario: Existing broad handler still catches new errors
+
+- **WHEN** code catches `BSBLANError` around a call that raises either
+  `BSBLANUnsupportedFeatureError` or `BSBLANMalformedResponseError`
+- **THEN** the exception is caught by the `BSBLANError` handler

--- a/src/bsblan/__init__.py
+++ b/src/bsblan/__init__.py
@@ -12,6 +12,8 @@ from .exceptions import (
     BSBLANAuthError,
     BSBLANConnectionError,
     BSBLANError,
+    BSBLANMalformedResponseError,
+    BSBLANUnsupportedFeatureError,
     BSBLANVersionError,
 )
 from .models import (
@@ -45,6 +47,8 @@ __all__ = [
     "BSBLANConfig",
     "BSBLANConnectionError",
     "BSBLANError",
+    "BSBLANMalformedResponseError",
+    "BSBLANUnsupportedFeatureError",
     "BSBLANVersionError",
     "DHWSchedule",
     "DHWTimeSwitchPrograms",

--- a/src/bsblan/_hot_water.py
+++ b/src/bsblan/_hot_water.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from .constants import ErrorMsg, HotWaterParams
-from .exceptions import BSBLANError
+from .exceptions import BSBLANError, BSBLANUnsupportedFeatureError
 from .models import (
     HotWaterConfig,
     HotWaterSchedule,
@@ -87,7 +87,10 @@ class HotWaterManager:
             The populated model instance.
 
         Raises:
-            BSBLANError: If no parameters are available for the filter.
+            BSBLANUnsupportedFeatureError: If the schedule group exposes no
+                parameters (a permanent condition).
+            BSBLANError: If no parameters are available for a non-schedule
+                group.
 
         """
         # Granular lazy load: validate only this param group on first access
@@ -105,6 +108,8 @@ class HotWaterManager:
         filtered_params = self._apply_include_filter(filtered_params, include)
 
         if not filtered_params:
+            if group_name == "schedule":
+                raise BSBLANUnsupportedFeatureError(error_msg)
             raise BSBLANError(error_msg)
 
         data = await self._request_named_params(filtered_params)

--- a/src/bsblan/_schedules.py
+++ b/src/bsblan/_schedules.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .constants import ErrorMsg, HeatingScheduleParams, HotWaterParams
-from .exceptions import BSBLANError
+from .exceptions import BSBLANError, BSBLANUnsupportedFeatureError
 from .models import HeatingTimeSwitchPrograms
 
 if TYPE_CHECKING:
@@ -62,7 +62,8 @@ class ScheduleManager:
             HeatingTimeSwitchPrograms: Heating schedule information.
 
         Raises:
-            BSBLANError: If no schedule parameters are available.
+            BSBLANUnsupportedFeatureError: If the device exposes no heating
+                schedule parameters (a permanent condition).
 
         """
         self._validate_circuit(circuit)
@@ -79,7 +80,7 @@ class ScheduleManager:
         }
 
         if not mapped_data:
-            raise BSBLANError(ErrorMsg.NO_HEATING_SCHEDULE_PARAMS)
+            raise BSBLANUnsupportedFeatureError(ErrorMsg.NO_HEATING_SCHEDULE_PARAMS)
 
         return HeatingTimeSwitchPrograms.model_validate(mapped_data)
 

--- a/src/bsblan/_transport.py
+++ b/src/bsblan/_transport.py
@@ -20,7 +20,7 @@ from packaging import version as pkg_version
 from yarl import URL
 
 from .constants import ErrorMsg
-from .exceptions import BSBLANAuthError, BSBLANError
+from .exceptions import BSBLANAuthError, BSBLANError, BSBLANMalformedResponseError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -110,8 +110,10 @@ class BSBLANTransport:
             dict[str, Any]: The JSON response from the BSBLAN device.
 
         Raises:
-            BSBLANError: If the session is missing or the response is invalid.
+            BSBLANError: If the session is missing.
             BSBLANAuthError: If authentication fails (401/403, not retried).
+            BSBLANMalformedResponseError: If the response body cannot be
+                decoded or parsed as JSON (a transient condition).
 
         """
         session = self._session_getter()
@@ -141,7 +143,7 @@ class BSBLANTransport:
         except (ValueError, UnicodeDecodeError) as e:
             # Handle JSON decode errors and other parsing issues
             msg = ErrorMsg.INVALID_RESPONSE.format(e)
-            raise BSBLANError(msg) from e
+            raise BSBLANMalformedResponseError(msg) from e
 
     @staticmethod
     async def _read_json(response: aiohttp.ClientResponse) -> dict[str, Any]:

--- a/src/bsblan/exceptions.py
+++ b/src/bsblan/exceptions.py
@@ -77,3 +77,20 @@ class BSBLANAuthError(BSBLANError):
     """Raised when authentication fails."""
 
     message: str = "Authentication failed. Please check your username and password."
+
+
+class BSBLANUnsupportedFeatureError(BSBLANError):
+    """Raised when the device does not support a requested feature.
+
+    This signals a permanent condition: the device does not expose the
+    requested parameters (for example a heating or hot water schedule), so
+    retrying the same request will never succeed.
+    """
+
+
+class BSBLANMalformedResponseError(BSBLANError):
+    """Raised when a device response cannot be decoded or parsed.
+
+    This signals a transient condition: the response body could not be decoded
+    or parsed as valid JSON, so a retry may succeed.
+    """

--- a/tests/test_bsblan_edge_cases.py
+++ b/tests/test_bsblan_edge_cases.py
@@ -9,7 +9,11 @@ import aiohttp
 import pytest
 
 from bsblan import BSBLAN, BSBLANConfig
-from bsblan.exceptions import BSBLANConnectionError, BSBLANError
+from bsblan.exceptions import (
+    BSBLANConnectionError,
+    BSBLANError,
+    BSBLANMalformedResponseError,
+)
 
 
 @pytest.mark.asyncio
@@ -77,8 +81,13 @@ async def test_value_error_path(monkeypatch: Any) -> None:
 
         monkeypatch.setattr(session, "request", MagicMock(return_value=mock_response))
 
-        with pytest.raises(BSBLANError, match="Invalid response format"):
+        with pytest.raises(
+            BSBLANMalformedResponseError, match="Invalid response format"
+        ) as exc_info:
             await bsblan._request()
+
+        # Transient error must remain catchable as the generic BSBLANError.
+        assert isinstance(exc_info.value, BSBLANError)
 
 
 def test_bsblan_config_initialization_edge_cases() -> None:

--- a/tests/test_heating_schedule.py
+++ b/tests/test_heating_schedule.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from bsblan.exceptions import BSBLANError
+from bsblan.exceptions import BSBLANError, BSBLANUnsupportedFeatureError
 from bsblan.models import HeatingTimeSwitchPrograms
 
 if TYPE_CHECKING:
@@ -138,8 +138,14 @@ async def test_heating_schedule_invalid_include_raises(mock_bsblan: BSBLAN) -> N
 
 @pytest.mark.asyncio
 async def test_heating_schedule_no_params_raises(mock_bsblan: BSBLAN) -> None:
-    """Test no schedule params in response raises error."""
+    """Test no schedule params in response raises unsupported-feature error."""
     mock_bsblan._request = AsyncMock(return_value={})  # type: ignore[method-assign]
 
-    with pytest.raises(BSBLANError, match="No heating schedule parameters available"):
+    with pytest.raises(
+        BSBLANUnsupportedFeatureError,
+        match="No heating schedule parameters available",
+    ) as exc_info:
         await mock_bsblan.heating_schedule(circuit=1)
+
+    # Permanent error must remain catchable as the generic BSBLANError.
+    assert isinstance(exc_info.value, BSBLANError)

--- a/tests/test_hot_water_additional.py
+++ b/tests/test_hot_water_additional.py
@@ -12,7 +12,7 @@ import pytest
 
 from bsblan import BSBLAN, BSBLANConfig
 from bsblan.constants import API_FULL
-from bsblan.exceptions import BSBLANError
+from bsblan.exceptions import BSBLANError, BSBLANUnsupportedFeatureError
 from bsblan.models import HotWaterConfig, HotWaterSchedule
 from bsblan.utility import APIValidator
 from tests import load_fixture
@@ -253,10 +253,13 @@ async def test_hot_water_schedule_no_params_error(
         bsblan._validator._validated_hot_water_groups.add("schedule")
 
         with pytest.raises(
-            BSBLANError,
+            BSBLANUnsupportedFeatureError,
             match="No hot water schedule parameters available",
-        ):
+        ) as exc_info:
             await bsblan.hot_water_schedule()
+
+        # Permanent error must remain catchable as the generic BSBLANError.
+        assert isinstance(exc_info.value, BSBLANError)
 
 
 @pytest.mark.asyncio
@@ -285,8 +288,11 @@ async def test_hot_water_state_no_params_error(
         with pytest.raises(
             BSBLANError,
             match="No essential hot water parameters available",
-        ):
+        ) as exc_info:
             await bsblan.hot_water_state()
+
+        # State group must NOT be reclassified as an unsupported-feature error.
+        assert not isinstance(exc_info.value, BSBLANUnsupportedFeatureError)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request introduces a new exception taxonomy to the library, allowing consumers to distinguish between permanent unsupported-feature errors and transient malformed-response errors. Two new exception classes are added—`BSBLANUnsupportedFeatureError` for permanent conditions and `BSBLANMalformedResponseError` for transient errors—both subclassing the existing `BSBLANError` to preserve backward compatibility. The changes affect schedule read paths, transport error handling, documentation, and tests.

**Exception taxonomy improvements:**
- Added `BSBLANUnsupportedFeatureError` and `BSBLANMalformedResponseError` as subclasses of `BSBLANError` in `src/bsblan/exceptions.py`, with docstrings describing their semantics (permanent vs. transient).
- Updated `src/bsblan/__init__.py` to import and re-export the new exceptions, and included them in `__all__` for top-level package access. [[1]](diffhunk://#diff-5b2498f42713c9e42aee64702da82bfd7c399f8ef66ec34779baff03026bead2R15-R16) [[2]](diffhunk://#diff-5b2498f42713c9e42aee64702da82bfd7c399f8ef66ec34779baff03026bead2R50-R51)

**Schedule read path changes (permanent error):**
- In `src/bsblan/_schedules.py` and `src/bsblan/_hot_water.py`, replaced bare `BSBLANError` raises with `BSBLANUnsupportedFeatureError` when schedule parameters are absent, and updated docstrings accordingly. [[1]](diffhunk://#diff-bbc607cfab1a636465d9fc32061a7738038d3c2389ae7b8ea2ba3659ee0421f1L8-R8) [[2]](diffhunk://#diff-bbc607cfab1a636465d9fc32061a7738038d3c2389ae7b8ea2ba3659ee0421f1L65-R66) [[3]](diffhunk://#diff-bbc607cfab1a636465d9fc32061a7738038d3c2389ae7b8ea2ba3659ee0421f1L82-R83) [[4]](diffhunk://#diff-ec928660e22bea816888852533ed6131966db3ac61802590b947446ea2534ca2L8-R8) [[5]](diffhunk://#diff-ec928660e22bea816888852533ed6131966db3ac61802590b947446ea2534ca2L90-R93) [[6]](diffhunk://#diff-ec928660e22bea816888852533ed6131966db3ac61802590b947446ea2534ca2R111-R112)

**Transport parse path changes (transient error):**
- In `src/bsblan/_transport.py`, replaced the generic error raise with `BSBLANMalformedResponseError` for decode/parse failures, and updated docstrings to document the new exception. [[1]](diffhunk://#diff-1b54b79358b5c1e98d27037eb32d963caed476d51f421d25270e768bdbff6953L23-R23) [[2]](diffhunk://#diff-1b54b79358b5c1e98d27037eb32d963caed476d51f421d25270e768bdbff6953L113-R116) [[3]](diffhunk://#diff-1b54b79358b5c1e98d27037eb32d963caed476d51f421d25270e768bdbff6953L144-R146)

**Documentation and specification:**
- Documented the new exceptions in `docs/api/exceptions.md` and updated the specification and design documentation to reflect the new taxonomy and requirements. [[1]](diffhunk://#diff-9c19bbc34c90f770a82ca120c9c7b4f413d3ef23bbbab0ed043b14bfa10b67bfR16-R23) [[2]](diffhunk://#diff-456c3064657f08a71afe852ec7ca56dc422cc0b1e91decb5930ab7e63ca213c5R1-R50) [[3]](diffhunk://#diff-b7b38c87a3290eb7eada8cfba1214f1ec9f9fc197d70fffdf5659abaa9c9965bR1-R59) [[4]](diffhunk://#diff-235b2beffd86245ac80bed2bd5b2e9655d9e78fb1ec5fd06e3a6f9c7e4aaacecR1-R101) [[5]](diffhunk://#diff-fa57a6f0c99ecb0eb90024c78e3d27bb6d712746c970d5edf60f512c5e6d5963R1-R49)

**Testing and validation:**
- Added and updated tests to assert the correct exception types are raised in all relevant scenarios, and ensured no regressions in unrelated error handling.

These changes are fully backward compatible: existing `except BSBLANError` handlers will continue to catch all library exceptions, while consumers can now opt into finer-grained error handling by catching the new exception types.