### PR TITLE
fix: treat "None" as an inactive value sentinel

### DIFF
--- a/src/bsblan/models.py
+++ b/src/bsblan/models.py
@@ -254,7 +254,11 @@ def _convert_bsblan_value(
         The converted value, or None if the value is inactive.
 
     """
-    if raw_value is None or raw_value in {"---", ""}:
+    # BSB-LAN's `replaceDisabled` setting decides what the firmware sends for a
+    # deactivated/inactive numeric parameter. It defaults to "---", but its own
+    # BSB_LAN_config.h documents "None" as the value Home Assistant users should
+    # pick, so both spellings reach us in the wild.
+    if raw_value is None or raw_value in {"---", "", "None"}:
         return None
 
     raw = str(raw_value)
@@ -302,7 +306,8 @@ class EntityInfo(BaseModel, Generic[T]):
     - ``EntityInfo[time]`` for HH:MM time values
     - ``EntityInfo[str]`` for string / datetime values
 
-    When the device returns ``"---"`` (sensor not in use), ``value`` is set
+    When the device returns ``"---"`` or ``"None"`` (sensor not in use, per
+    BSB-LAN's ``replaceDisabled`` setting), ``value`` is set
     to ``None``.
 
     Attributes:

--- a/tests/test_entity_info.py
+++ b/tests/test_entity_info.py
@@ -31,11 +31,12 @@ def test_entity_info_invalid_time_conversion(
     [
         pytest.param("---", id="dash_inactive"),
         pytest.param("", id="empty_string"),
+        pytest.param("None", id="none_string_inactive"),
         pytest.param(None, id="none_value"),
     ],
 )
 def test_entity_info_undefined_value_becomes_none(raw_value: str | None) -> None:
-    """Test that inactive values ('---', '', None) are converted to None."""
+    """Test that inactive values ('---', '', 'None', None) become None."""
     entity = EntityInfo(
         name="Inactive Sensor",
         value=raw_value,


### PR DESCRIPTION
Fixes #1572.

BSB-LAN's `replaceDisabled` firmware setting decides what is sent for a deactivated numeric parameter. It defaults to `"---"`, but Home Assistant's MQTT platform requires the literal string `"None"` to mark a sensor unknown (`PAYLOAD_NONE`); with `"---"`, numeric MQTT sensors keep their last value forever. BSB-LAN's config file therefore tells Home Assistant users to set `"None"` — and doing so currently prevents this integration from starting (`float_parsing` on `State.current_temperature.value`).

As it stands, the two official HA paths for BSB-LAN need incompatible firmware settings. This adds `"None"` to the inactive sentinel set so a single device can serve both, and covers it in the existing parameterized test.

I deliberately kept this minimal and did **not** touch the "keep the raw string on conversion failure" behaviour, since it is explicitly asserted by three tests — see the issue for why I think it is nonetheless unsafe for parameterized `EntityInfo[float]` / `EntityInfo[int]` fields. Happy to follow up separately if you want that changed.

Full suite: 475 passed. (`examples/speed_test.py` errors on collection on `main` too, unrelated.)
